### PR TITLE
Add slash command, command handler, event handler, command deployment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,8 @@
         "brace-style": ["warn", "1tbs",  { "allowSingleLine": true }],
         "indent": ["error", 4, { "SwitchCase": 1 }],
         "no-empty-function": "warn",
-        "no-unused-vars": ["error", { "varsIgnorePattern": "^_" }],
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_" }],
         "quotes": ["error", "single", { "allowTemplateLiterals": true }],
         "semi": ["error", "always"],
         "space-before-function-paren": ["error", {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "start": "ts-node src/index.ts",
+    "deploy-commands": "ts-node src/util/deploy-commands.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,0 +1,13 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction } from 'discord.js';
+import { CustomCommand } from '../types/customCommand.js';
+
+export default class InfoCommand implements CustomCommand {
+    data = new SlashCommandBuilder()
+        .setName('info')
+        .setDescription('Display Tournamention bot information');
+
+    execute = async (interaction: CommandInteraction) => {
+        interaction.reply(`${'Hello world!'}`);
+    };
+}

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -2,12 +2,13 @@ import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction } from 'discord.js';
 import { CustomCommand } from '../types/customCommand.js';
 
-export default class InfoCommand implements CustomCommand {
-    data = new SlashCommandBuilder()
+const InfoCommand = new CustomCommand(
+    new SlashCommandBuilder()
         .setName('info')
-        .setDescription('Display Tournamention bot information');
+        .setDescription('Display Tournamention bot information.'),
+    async (interaction: CommandInteraction) => {
+        interaction.reply('Hello world!');
+    }
+);
 
-    execute = async (interaction: CommandInteraction) => {
-        interaction.reply(`${'Hello world!'}`);
-    };
-}
+export default InfoCommand;

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -5,9 +5,11 @@ import { CustomCommand } from '../types/customCommand.js';
 const InfoCommand = new CustomCommand(
     new SlashCommandBuilder()
         .setName('info')
-        .setDescription('Display Tournamention bot information.'),
+        .setDescription('Display Tournamention bot information.')
+        .addStringOption(option => option.setName('info').setDescription('The information to display.').setRequired(false)) as SlashCommandBuilder,
     async (interaction: CommandInteraction) => {
-        interaction.reply('Hello world!');
+        console.log('Hello world!');
+        interaction.reply({ content: `Hello world! ${interaction.options.get('info')?.value}`, ephemeral: true });
     }
 );
 

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,34 +1,30 @@
 import { BaseInteraction, ChatInputCommandInteraction } from 'discord.js';
-import { TournamentionClient } from 'src/types/client';
+import { TournamentionClient } from '../types/client.js';
+import { CustomEvent } from '../types/customEvent.js';
 
-export const name = 'interactionCreate';
-export const execute = async (interaction: BaseInteraction) => {
-    if (!interaction.isCommand() && !interaction.isButton() && !interaction.isModalSubmit()) return;
+const interactionCreate = new CustomEvent(
+    'interactionCreate',
+    async (interaction: BaseInteraction) => {
+        if (!interaction.isCommand() && !interaction.isButton() && !interaction.isModalSubmit()) return;
 
-    const tournamentionClient = await TournamentionClient.getInstance();
+        const tournamentionClient = await TournamentionClient.getInstance();
 
-    if (interaction.isCommand()) {
-        const command = tournamentionClient.getCommand((<ChatInputCommandInteraction> interaction).commandName);
-        if (!command) {
+        if (interaction.isCommand()) {
+            const command = tournamentionClient.getCommand((<ChatInputCommandInteraction> interaction).commandName);
+            if (!command) {
+                return;
+            }
+            try {
+                command.execute(interaction);
+            } catch (error) {
+                console.error(error);
+                interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+            }
+        } else if (interaction.isButton()) {
+            // TODO: Adapt code from Condemned Souls bot...
             return;
         }
-        try {
-            command.execute(interaction);
-        } catch (error) {
-            console.error(error);
-            interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
-        }
-    } else if (interaction.isButton()) {
-        // const button = interaction.client.buttons.get(interaction.customId);
-        // if (!button) {
-        //     return;
-        // }
-        // try {
-        //     button.execute(interaction);
-        // } catch (error) {
-        //     console.error(error);
-        //     interaction.reply({ content: 'There was an error while pressing this button!', ephemeral: true });
-        // }
-        return;
     }
-};
+);
+
+export default interactionCreate;

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,0 +1,34 @@
+import { BaseInteraction, ChatInputCommandInteraction } from 'discord.js';
+import { TournamentionClient } from 'src/types/client';
+
+export const name = 'interactionCreate';
+export const execute = async (interaction: BaseInteraction) => {
+    if (!interaction.isCommand() && !interaction.isButton() && !interaction.isModalSubmit()) return;
+
+    const tournamentionClient = await TournamentionClient.getInstance();
+
+    if (interaction.isCommand()) {
+        const command = tournamentionClient.getCommand((<ChatInputCommandInteraction> interaction).commandName);
+        if (!command) {
+            return;
+        }
+        try {
+            command.execute(interaction);
+        } catch (error) {
+            console.error(error);
+            interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+        }
+    } else if (interaction.isButton()) {
+        // const button = interaction.client.buttons.get(interaction.customId);
+        // if (!button) {
+        //     return;
+        // }
+        // try {
+        //     button.execute(interaction);
+        // } catch (error) {
+        //     console.error(error);
+        //     interaction.reply({ content: 'There was an error while pressing this button!', ephemeral: true });
+        // }
+        return;
+    }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import dotenv from 'dotenv';
 dotenv.config();
-import { Client } from 'discord.js';
+import fs from 'fs';
+import path from 'path';
 import mongoose from 'mongoose';
 import example from './example.js';
 import example2 from './example2.js';
+import { TournamentionClient } from './types/client.js';
 
 // Database connection
 mongoose.connect(process.env.DB_URI as string)
@@ -13,9 +15,18 @@ mongoose.connect(process.env.DB_URI as string)
         console.log(`Error connecting to database: ${err}}`);
     });
 
-const client = new Client({
-    intents: [],
-});
+const client = await TournamentionClient.getInstance();
+
+// APPLICATION COMMANDS
+const commandsPath = path.join(__dirname, 'commands');
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js') || file.endsWith('.ts'));
+
+for (const file of commandFiles) {
+    const filePath = path.join(commandsPath, file);
+    const command = await import(filePath);
+    client.addCommands([{ name: command.data.name, command: command }]);
+}
+
 client.login(process.env.DISCORD_TOKEN);
 
 console.log(example());

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import example from './example.js';
 import example2 from './example2.js';
 import { TournamentionClient } from './types/client.js';
 import { prepareCommands } from './util/commandHandler.js';
+import { prepareEvents } from './util/eventHandler.js';
 
 // Database connection
 mongoose.connect(process.env.DB_URI as string)
@@ -18,6 +19,9 @@ const client = await TournamentionClient.getInstance();
 
 // APPLICATION COMMANDS
 prepareCommands(client);
+
+// EVENTS
+prepareEvents(client);
 
 client.login(process.env.DISCORD_TOKEN);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import dotenv from 'dotenv';
 dotenv.config();
-import fs from 'fs';
-import path from 'path';
 import mongoose from 'mongoose';
 import example from './example.js';
 import example2 from './example2.js';
 import { TournamentionClient } from './types/client.js';
+import { prepareCommands } from './util/commandHandler.js';
 
 // Database connection
 mongoose.connect(process.env.DB_URI as string)
@@ -18,18 +17,9 @@ mongoose.connect(process.env.DB_URI as string)
 const client = await TournamentionClient.getInstance();
 
 // APPLICATION COMMANDS
-const commandsPath = path.join(__dirname, 'commands');
-const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js') || file.endsWith('.ts'));
-
-for (const file of commandFiles) {
-    const filePath = path.join(commandsPath, file);
-    const command = await import(filePath);
-    client.addCommands([{ name: command.data.name, command: command }]);
-}
+prepareCommands(client);
 
 client.login(process.env.DISCORD_TOKEN);
 
 console.log(example());
 console.log(example2());
-
-export const index = {};

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,0 +1,40 @@
+import { ChatInputApplicationCommandData, Client, Collection } from 'discord.js';
+
+export type SlashCommandCollectionPair = {
+    name: string;
+    command: ChatInputApplicationCommandData;
+}
+
+export class TournamentionClient extends Client {
+    private static instance: TournamentionClient;
+    private commands: Collection<string, ChatInputApplicationCommandData>;
+
+    private constructor() {
+        super({
+            intents: [],
+        });
+        this.commands = new Collection();
+        TournamentionClient.instance = this;
+    }
+
+    public addCommands(commands: SlashCommandCollectionPair[]): void {
+        commands.forEach(com => {
+            this.commands.set(com.name, com.command);
+        });
+    }
+
+    public getCommands(): Collection<string, ChatInputApplicationCommandData> {
+        return this.commands;
+    }
+
+    public getCommand(name: string): ChatInputApplicationCommandData | undefined {
+        return this.commands.get(name);
+    }
+
+    public static async getInstance(): Promise<TournamentionClient> {
+        if (!TournamentionClient.instance) {
+            TournamentionClient.instance = new TournamentionClient();
+        }
+        return TournamentionClient.instance;
+    }
+}

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,13 +1,14 @@
-import { ChatInputApplicationCommandData, Client, Collection } from 'discord.js';
+import { Client, Collection } from 'discord.js';
+import { CustomCommand } from './customCommand.js';
 
 export type SlashCommandCollectionPair = {
     name: string;
-    command: ChatInputApplicationCommandData;
+    command: CustomCommand;
 }
 
 export class TournamentionClient extends Client {
     private static instance: TournamentionClient;
-    private commands: Collection<string, ChatInputApplicationCommandData>;
+    private commands: Collection<string, CustomCommand>;
 
     private constructor() {
         super({
@@ -23,11 +24,11 @@ export class TournamentionClient extends Client {
         });
     }
 
-    public getCommands(): Collection<string, ChatInputApplicationCommandData> {
+    public getCommands(): Collection<string, CustomCommand> {
         return this.commands;
     }
 
-    public getCommand(name: string): ChatInputApplicationCommandData | undefined {
+    public getCommand(name: string): CustomCommand | undefined {
         return this.commands.get(name);
     }
 

--- a/src/types/customCommand.ts
+++ b/src/types/customCommand.ts
@@ -1,0 +1,6 @@
+import { CommandInteraction, SlashCommandBuilder } from 'discord.js';
+
+export interface CustomCommand {
+    data: SlashCommandBuilder;
+    execute: (interaction: CommandInteraction) => void;
+}

--- a/src/types/customCommand.ts
+++ b/src/types/customCommand.ts
@@ -1,6 +1,10 @@
 import { CommandInteraction, SlashCommandBuilder } from 'discord.js';
 
-export interface CustomCommand {
+export class CustomCommand {
     data: SlashCommandBuilder;
     execute: (interaction: CommandInteraction) => void;
+    constructor(data: SlashCommandBuilder, execute: (interaction: CommandInteraction) => void) {
+        this.data = data;
+        this.execute = execute;
+    }
 }

--- a/src/types/customEvent.ts
+++ b/src/types/customEvent.ts
@@ -1,0 +1,12 @@
+import { BaseInteraction } from 'discord.js';
+
+export class CustomEvent {
+    name: string;
+    execute: (interaction: BaseInteraction) => void;
+    once: boolean;
+    constructor(name: string, execute: (interaction: BaseInteraction) => void, once?: boolean) {
+        this.name = name;
+        this.execute = execute;
+        this.once = once ?? false;
+    }
+}

--- a/src/util/commandHandler.ts
+++ b/src/util/commandHandler.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL, fileURLToPath } from 'url';
+import { TournamentionClient } from 'src/types/client';
+import { CustomCommand } from 'src/types/customCommand';
+
+export const prepareCommands = async (client: TournamentionClient) => {
+    const commandsPath = pathToFileURL(path.join(process.cwd(), './src/commands'));
+    const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js') || file.endsWith('.ts'));
+
+    for (const file of commandFiles) {
+        const filePath = pathToFileURL(path.join(fileURLToPath(commandsPath), file)).toString();
+        const command = (await import(filePath)).default as CustomCommand;
+        client.addCommands([{ name: command.data.name, command: command }]);
+    }
+};

--- a/src/util/deploy-commands.ts
+++ b/src/util/deploy-commands.ts
@@ -1,0 +1,25 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL, fileURLToPath } from 'url';
+import { REST } from '@discordjs/rest';
+import { Routes } from 'discord-api-types/v9';
+import { CustomCommand } from '../types/customCommand.js';
+import { RESTPostAPIApplicationCommandsJSONBody } from 'discord.js';
+
+const commands = new Array<RESTPostAPIApplicationCommandsJSONBody>();
+const commandsPath = pathToFileURL(path.join(process.cwd(), './src/commands'));
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js') || file.endsWith('.ts'));
+
+for (const file of commandFiles) {
+    const filePath = pathToFileURL(path.join(fileURLToPath(commandsPath), file)).toString();
+    const command = (await import(filePath)).default as CustomCommand;
+    commands.push(command.data.toJSON());
+}
+
+const rest = new REST({ version: '9' }).setToken(process.env.DISCORD_TOKEN as string);
+
+rest.put(Routes.applicationGuildCommands(process.env.CLIENT_ID as string, process.env.TESTING_GUILD_ID as string), { body: commands })
+    .then(() => console.log('Successfully registered application commands.'))
+    .catch(console.error);

--- a/src/util/eventHandler.ts
+++ b/src/util/eventHandler.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import { TournamentionClient } from 'src/types/client.js';
+import { CustomEvent } from 'src/types/customEvent.js';
+import { pathToFileURL, fileURLToPath } from 'url';
+
+export const prepareEvents = async (client: TournamentionClient) => {
+    const eventsPath = pathToFileURL(path.join(process.cwd(), './src/events'));
+    const eventFiles = fs.readdirSync(eventsPath).filter(file => file.endsWith('.js') || file.endsWith('.ts'));
+    for (const file of eventFiles) {
+        // const filePath = path.join(eventsPath, file);
+        // const event = require(filePath);
+        const filePath = pathToFileURL(path.join(fileURLToPath(eventsPath), file)).toString();
+        const event = (await import(filePath)).default as CustomEvent;
+        if (event.once) {
+            client.once(event.name, (args) => event.execute(args));
+        } else {
+            client.on(event.name, (args) => event.execute(args));
+        }
+    }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "target": "ES6",
-        "module": "ES6",
+        "target": "ES2022",
+        "module": "ES2022",
         "rootDir": "./src/",
         "outDir": "./dist/",
         "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,14 +25,15 @@
     "ts-node": {
         "esm": true,
         "compilerOptions": {
-            "module": "ES6"
+            "module": "ES2022",
+            "target": "ES2022"
         }
     },
     "files": [
         "src/index.ts"
     ],
     "include": [
-        "./**/*.ts"
+        "src/**/*.ts"
     ],
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Closes #10 

This feature branch introduces slash command creation functionality. It introduces frameworks for creating custom commands and events in a robust and typechecked framework for future development. Also included is a client subclass where properties can be assigned (in contrast to the ability to freely add properties to the client object in regular JS like we did on the Condemned Souls bot). TournamentionClient is written in the Singleton design pattern. Lastly, it includes a template slash command.