### PR TITLE
Add create-challenge command, error handling and typechecking utilities, auto GuildSettings creation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,5 +23,9 @@
         }],
         "space-in-parens": ["error", "never"],
         "space-infix-ops": "error"
-    }
+    },
+    "ignorePatterns": [
+        "node_modules/",
+        "dist/"
+    ]
 }

--- a/src/backend/queries/guildSettingsQueries.ts
+++ b/src/backend/queries/guildSettingsQueries.ts
@@ -1,9 +1,31 @@
+import { GuildSettingsDocument, TournamentDocument } from '../../types/customDocument.js';
 import { GuildSettingsModel } from '../schemas/guildsettings.js';
 // CREATE / POST
+export const createGuildSettings = async (guildID: string): Promise<GuildSettingsDocument> => {
+    return GuildSettingsModel.create({
+        guildID: guildID,
+    });
+};
 
 // READ / GET
-export const getGuildSettings = async (guildID: string) => {
+export const getGuildSettings = async (guildID: string): Promise<GuildSettingsDocument | null> => {
     return GuildSettingsModel.findOne({ guildID: guildID });
+};
+
+export const getOrCreateGuildSettings = async (guildID: string): Promise<GuildSettingsDocument> => {
+    const guildSettings = await getGuildSettings(guildID);
+    return guildSettings ? guildSettings : createGuildSettings(guildID);
+};
+
+/**
+ * Gets the current tournament of a guild, creating a GuildSettings document if one does not exist as a side-effect.
+ * @param guildID The Discord Snowflake ID of the guild.
+ * @returns A Promise that resolves to the current TournamentDocument of the guild, or null if one 
+ * does not exist (e.g. there are no active Tournaments).
+ */
+export const getCurrentTournament = async (guildID: string): Promise<TournamentDocument | null> => {
+    const serverSettings = await getOrCreateGuildSettings(guildID);
+    return serverSettings.getCurrentTournament();
 };
 
 // UPDATE / PUT

--- a/src/backend/queries/guildSettingsQueries.ts
+++ b/src/backend/queries/guildSettingsQueries.ts
@@ -1,4 +1,4 @@
-import { GuildSettingsModel } from '../schemas/guildsettings';
+import { GuildSettingsModel } from '../schemas/guildsettings.js';
 // CREATE / POST
 
 // READ / GET

--- a/src/backend/queries/guildSettingsQueries.ts
+++ b/src/backend/queries/guildSettingsQueries.ts
@@ -1,0 +1,11 @@
+import { GuildSettingsModel } from '../schemas/guildsettings';
+// CREATE / POST
+
+// READ / GET
+export const getGuildSettings = async (guildID: string) => {
+    return GuildSettingsModel.findOne({ guildID: guildID });
+};
+
+// UPDATE / PUT
+
+// DELETE

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -87,6 +87,10 @@ export const getTournamentsByGuild = async (guildID: string) => {
     return TournamentModel.find({ guildID: guildID });
 };
 
+export const getTournamentByName = async (guildID: string, name: string): Promise<TournamentDocument | null> => {
+    return TournamentModel.findOne({ guildID: guildID, name: name });
+};
+
 // UPDATE / PUT
 interface UpdateTournamentParams {
     name?: string;

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -3,7 +3,7 @@ import { Tournament, TournamentModel } from '../schemas/tournament.js';
 import { Challenge } from '../schemas/challenge.js';
 import { DuplicateSubdocumentError } from '../../types/customError.js';
 import { Difficulty } from '../schemas/difficulty.js';
-import { TournamentDocument } from 'src/types/customDocument.js';
+import { TournamentDocument } from '../../types/customDocument.js';
 
 // CREATE / POST
 export const createTournament = async (guildID: string, name: string, photoURI: string, active: boolean, statusDescription: string, visibility: boolean, duration: string): Promise<TournamentDocument> => {

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -130,7 +130,7 @@ export const addChallengeToTournament = async (tournamentID: Ref<Tournament>, ch
     const tournament = await TournamentModel.findById(tournamentID);
     if (!tournament) throw new Error('Error in addChallengeToTournament: Tournament not found.');
     for (const existingChallenge of tournament.challenges) {
-        if (existingChallenge.name === challenge.name) throw new DuplicateSubdocumentError(`Error in addChallengeToTournament: Challenge already exists in tournament. DEBUG: ${tournament.challenges}`);
+        if (existingChallenge.name === challenge.name) throw new DuplicateSubdocumentError(`Error in addChallengeToTournament: Challenge already exists in tournament.`);
     }
     tournament.challenges.push(challenge);
     return tournament.save();

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from 'mongodb';
 import { Ref } from '@typegoose/typegoose';
 import { Tournament, TournamentModel } from '../schemas/tournament.js';
 import { DuplicateSubdocumentError, UserMessageError } from '../../types/customError.js';
@@ -79,7 +80,7 @@ export class TournamentBuilder {
 }
 
 // READ / GET
-export const getTournamentById = async (id: Ref<Tournament>): Promise<TournamentDocument | null> => {
+export const getTournamentById = async (id: ObjectId): Promise<TournamentDocument | null> => {
     return TournamentModel.findById(id);
 };
 
@@ -125,11 +126,11 @@ export const updateTournament = async (id: Ref<Tournament>, name?: string, photo
     return TournamentModel.findByIdAndUpdate(id, { $set: update });
 };
 
-export const addChallengeToTournament = async (tournamentID: Ref<Tournament>, challenge: Challenge): Promise<TournamentDocument> => {
+export const addChallengeToTournament = async (tournamentID: Ref<Tournament>, challenge: ChallengeDocument): Promise<TournamentDocument> => {
     const tournament = await TournamentModel.findById(tournamentID);
     if (!tournament) throw new Error('Error in addChallengeToTournament: Tournament not found.');
-    for (const challenge of tournament.challenges) {
-        if (challenge.name === challenge.name) throw new DuplicateSubdocumentError('Error in addChallengeToTournament: Challenge already exists in tournament.');
+    for (const existingChallenge of tournament.challenges) {
+        if (existingChallenge.name === challenge.name) throw new DuplicateSubdocumentError(`Error in addChallengeToTournament: Challenge already exists in tournament. DEBUG: ${tournament.challenges}`);
     }
     tournament.challenges.push(challenge);
     return tournament.save();

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -3,9 +3,10 @@ import { Tournament, TournamentModel } from '../schemas/tournament.js';
 import { Challenge } from '../schemas/challenge.js';
 import { DuplicateSubdocumentError } from '../../types/customError.js';
 import { Difficulty } from '../schemas/difficulty.js';
+import { TournamentDocument } from 'src/types/customDocument.js';
 
 // CREATE / POST
-export const createTournament = async (guildID: string, name: string, photoURI: string, active: boolean, statusDescription: string, visibility: boolean, duration: string) => {
+export const createTournament = async (guildID: string, name: string, photoURI: string, active: boolean, statusDescription: string, visibility: boolean, duration: string): Promise<TournamentDocument> => {
     return TournamentModel.create({
         guildID: guildID,
         name: name,
@@ -64,7 +65,7 @@ export class TournamentBuilder {
         return this;
     }
 
-    public async buildForGuild(guildID: string): Promise<Tournament> {
+    public async buildForGuild(guildID: string): Promise<TournamentDocument> {
         if (!guildID || !this.name) throw new Error('Error in TournamentBuilder: A required property in {guildID, name} not set.');
         return TournamentModel.create({
             guildID: guildID,
@@ -79,11 +80,11 @@ export class TournamentBuilder {
 }
 
 // READ / GET
-export const getTournamentById = async (id: Ref<Tournament>) => {
+export const getTournamentById = async (id: Ref<Tournament>): Promise<TournamentDocument | null> => {
     return TournamentModel.findById(id);
 };
 
-export const getTournamentsByGuild = async (guildID: string) => {
+export const getTournamentsByGuild = async (guildID: string): Promise<TournamentDocument[] | null> => {
     return TournamentModel.find({ guildID: guildID });
 };
 
@@ -101,7 +102,7 @@ interface UpdateTournamentParams {
     duration?: string;
 }
 
-export const updateTournament = async (id: Ref<Tournament>, name?: string, photoURI?: string, active?: boolean, statusDescription?: string, visibility?: boolean, duration?: string) => {
+export const updateTournament = async (id: Ref<Tournament>, name?: string, photoURI?: string, active?: boolean, statusDescription?: string, visibility?: boolean, duration?: string): Promise<TournamentDocument | null> => {
     const update: UpdateTournamentParams = {};
     if (name !== undefined) update.name = name;
     if (photoURI !== undefined) update.photoURI = photoURI;
@@ -113,7 +114,7 @@ export const updateTournament = async (id: Ref<Tournament>, name?: string, photo
     return TournamentModel.findByIdAndUpdate(id, { $set: update });
 };
 
-export const addChallengeToTournament = async (tournamentID: Ref<Tournament>, challenge: Challenge) => {
+export const addChallengeToTournament = async (tournamentID: Ref<Tournament>, challenge: Challenge): Promise<TournamentDocument> => {
     const tournament = await TournamentModel.findById(tournamentID);
     if (!tournament) throw new Error('Error in addChallengeToTournament: Tournament not found.');
     for (const challenge of tournament.challenges) {
@@ -123,7 +124,7 @@ export const addChallengeToTournament = async (tournamentID: Ref<Tournament>, ch
     return tournament.save();
 };
 
-export const addDifficultyToTournament = async (tournamentID: Ref<Tournament>, difficulty: Difficulty) => {
+export const addDifficultyToTournament = async (tournamentID: Ref<Tournament>, difficulty: Difficulty): Promise<TournamentDocument> => {
     const tournament = await TournamentModel.findById(tournamentID);
     if (!tournament) throw new Error('Error in addDifficultyToTournament: Tournament not found.');
     for (const difficulty of tournament.difficulties) {
@@ -134,6 +135,6 @@ export const addDifficultyToTournament = async (tournamentID: Ref<Tournament>, d
 };
 
 // DELETE
-export const deleteTournament = async (id: Ref<Tournament>) => {
+export const deleteTournament = async (id: Ref<Tournament>): Promise<TournamentDocument | null> => {
     return TournamentModel.findByIdAndDelete(id);
 };

--- a/src/backend/schemas/challenge.ts
+++ b/src/backend/schemas/challenge.ts
@@ -11,8 +11,8 @@ export class Challenge {
     @prop({ required: true })
     public description!: string;
 
-    @prop({ required: true, ref: () => Difficulty })
-    public difficulty!: Ref<Difficulty>;
+    @prop({ ref: () => Difficulty })
+    public difficulty?: Ref<Difficulty>;
 
     @prop({ required: true })
     public game!: string;

--- a/src/backend/schemas/challenge.ts
+++ b/src/backend/schemas/challenge.ts
@@ -11,7 +11,7 @@ export class Challenge {
     @prop({ required: true })
     public description!: string;
 
-    @prop({ required: true, type: () => Difficulty })
+    @prop({ required: true, ref: () => Difficulty })
     public difficulty!: Ref<Difficulty>;
 
     @prop({ required: true })

--- a/src/backend/schemas/guildsettings.ts
+++ b/src/backend/schemas/guildsettings.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb';
 import { Document } from 'mongoose';
 import { prop, getModelForClass } from '@typegoose/typegoose';
 import { TournamentModel, Tournament } from './tournament.js';
-import { TournamentDocument } from 'src/types/customDocument.js';
+import { TournamentDocument } from '../../types/customDocument.js';
 
 export class GuildSettings {
     @prop({ required: true, unique: true })

--- a/src/backend/schemas/guildsettings.ts
+++ b/src/backend/schemas/guildsettings.ts
@@ -1,13 +1,14 @@
 import { ObjectId } from 'mongodb';
 import { Document } from 'mongoose';
 import { prop, getModelForClass } from '@typegoose/typegoose';
-import { TournamentModel, Tournament, TournamentDocument } from './tournament.js';
+import { TournamentModel, Tournament } from './tournament.js';
+import { TournamentDocument } from 'src/types/customDocument.js';
 
 export class GuildSettings {
     @prop({ required: true, unique: true })
     public guildID!: string;
 
-    public async getCurrentTournament() {
+    public async getCurrentTournament(): Promise<TournamentDocument | null> {
         // TODO: default value in reduce may not work in practice
         // TODO: test performance WRT frequent .toObject() calls, would a separate array of Tournament be faster?
         const guildTournaments = (await TournamentModel.find({ guildID: this.guildID }));

--- a/src/backend/schemas/guildsettings.ts
+++ b/src/backend/schemas/guildsettings.ts
@@ -1,25 +1,27 @@
 import { ObjectId } from 'mongodb';
 import { Document } from 'mongoose';
-import { prop, getModelForClass, /*DocumentType*/ } from '@typegoose/typegoose';
-import { TournamentModel, Tournament } from './tournament.js';
+import { prop, getModelForClass } from '@typegoose/typegoose';
+import { TournamentModel, Tournament, TournamentDocument } from './tournament.js';
 
 export class GuildSettings {
     @prop({ required: true, unique: true })
     public guildID!: string;
 
-    public async getCurrentTournament(/*this: DocumentType<GuildSettings>*/) {
+    public async getCurrentTournament() {
+        // TODO: default value in reduce may not work in practice
+        // TODO: test performance WRT frequent .toObject() calls, would a separate array of Tournament be faster?
         const guildTournaments = (await TournamentModel.find({ guildID: this.guildID }));
         const activeTournament = guildTournaments
-            .map((t: Document<ObjectId, unknown, Tournament>) => {
-                return t.toObject();
+            .filter((t: TournamentDocument) => {
+                return t.toObject().active;
             })
-            .filter((t: Tournament) => {
-                return t.active;
-            })
-            .reduce((prev: Tournament, curr: Tournament) => {
-                // TODO: this may not work
-                return !prev.name && prev._id.getTimestamp().getTime() > curr._id.getTimestamp().getTime() ? prev : curr;
-            }, new Tournament());
+            .reduce((prev: TournamentDocument, curr: TournamentDocument) => {
+                const prevTournament: Tournament = prev.toObject();
+                const currTournament: Tournament = curr.toObject();
+                return !prevTournament.name 
+                    && prevTournament._id.getTimestamp().getTime() > currTournament._id.getTimestamp().getTime() 
+                    ? prev : curr;
+            }, new Document<ObjectId, unknown, Tournament>() as TournamentDocument);
         return activeTournament ? activeTournament : null;
     }
 }

--- a/src/backend/schemas/guildsettings.ts
+++ b/src/backend/schemas/guildsettings.ts
@@ -1,5 +1,3 @@
-import { ObjectId } from 'mongodb';
-import { Document } from 'mongoose';
 import { prop, getModelForClass } from '@typegoose/typegoose';
 import { TournamentModel, Tournament } from './tournament.js';
 import { TournamentDocument } from '../../types/customDocument.js';
@@ -9,7 +7,6 @@ export class GuildSettings {
     public guildID!: string;
 
     public async getCurrentTournament(): Promise<TournamentDocument | null> {
-        // TODO: default value in reduce may not work in practice
         // TODO: test performance WRT frequent .toObject() calls, would a separate array of Tournament be faster?
         const guildTournaments = (await TournamentModel.find({ guildID: this.guildID }));
         const activeTournament = guildTournaments
@@ -22,7 +19,7 @@ export class GuildSettings {
                 return !prevTournament.name 
                     && prevTournament._id.getTimestamp().getTime() > currTournament._id.getTimestamp().getTime() 
                     ? prev : curr;
-            }, new Document<ObjectId, unknown, Tournament>() as TournamentDocument);
+            });
         return activeTournament ? activeTournament : null;
     }
 }

--- a/src/backend/schemas/submission.ts
+++ b/src/backend/schemas/submission.ts
@@ -14,7 +14,7 @@ export enum SubmissionStatus {
 export class ReviewNote {
     _id!: ObjectId;
 
-    @prop({ required: true, type: () => Judge})
+    @prop({ required: true, ref: () => Judge})
     public judgeID!: Ref<Judge>;
 
     @prop({ required: true })
@@ -25,10 +25,10 @@ export class ReviewNote {
 }
 
 export class Submission {
-    @prop({ required: true, type: () => Challenge, index: true })
+    @prop({ required: true, ref: () => Challenge, index: true })
     public challengeID!: Ref<Challenge>;
 
-    @prop({ required: true, type: () => Contestant, index: true })
+    @prop({ required: true, ref: () => Contestant, index: true })
     public contestantID!: Ref<Contestant>;
 
     @prop({ required: true })

--- a/src/backend/schemas/tournament.ts
+++ b/src/backend/schemas/tournament.ts
@@ -1,9 +1,7 @@
 import { ObjectId } from 'mongodb';
-import { Document } from 'mongoose';
 import { prop, index, getModelForClass } from '@typegoose/typegoose';
 import { Challenge } from './challenge.js';
 import { Difficulty } from './difficulty.js';
-import { BeAnObject, IObjectWithTypegooseFunction } from '@typegoose/typegoose/lib/types.js';
 
 @index({ guildID: 1, name: 1 }, { unique: true })
 export class Tournament {
@@ -38,5 +36,3 @@ export class Tournament {
 }
 
 export const TournamentModel = getModelForClass(Tournament);
-
-export type TournamentDocument = (Document<ObjectId, BeAnObject, Tournament> & Omit<Tournament & Required<{ _id: ObjectId; }>, 'typegooseName'> & IObjectWithTypegooseFunction);

--- a/src/backend/schemas/tournament.ts
+++ b/src/backend/schemas/tournament.ts
@@ -1,7 +1,9 @@
 import { ObjectId } from 'mongodb';
+import { Document } from 'mongoose';
 import { prop, index, getModelForClass } from '@typegoose/typegoose';
 import { Challenge } from './challenge.js';
 import { Difficulty } from './difficulty.js';
+import { BeAnObject, IObjectWithTypegooseFunction } from '@typegoose/typegoose/lib/types.js';
 
 @index({ guildID: 1, name: 1 }, { unique: true })
 export class Tournament {
@@ -36,3 +38,5 @@ export class Tournament {
 }
 
 export const TournamentModel = getModelForClass(Tournament);
+
+export type TournamentDocument = (Document<ObjectId, BeAnObject, Tournament> & Omit<Tournament & Required<{ _id: ObjectId; }>, 'typegooseName'> & IObjectWithTypegooseFunction);

--- a/src/commands/create-challenge.ts
+++ b/src/commands/create-challenge.ts
@@ -1,0 +1,182 @@
+import { ObjectId } from 'mongodb';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction, CommandInteractionOptionResolver } from 'discord.js';
+import { CustomCommand } from '../types/customCommand.js';
+import { addChallengeToTournament, getDifficultyByEmoji, getTournamentById, getTournamentByName } from '../backend/queries/tournamentQueries.js';
+import { ChallengeDocument, DifficultyDocument, TournamentDocument } from '../types/customDocument.js';
+import { Challenge, ChallengeModel } from '../backend/schemas/challenge.js';
+import { DuplicateSubdocumentError, UserFacingError } from '../types/customError.js';
+import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
+
+/**
+ * An alias for the type of `interaction.options`.
+ */
+type CommandInteractionOptionResolverAlias = Omit<
+CommandInteractionOptionResolver,
+| 'getMessage'
+| 'getFocused'
+| 'getMentionable'
+| 'getRole'
+| 'getAttachment'
+| 'getNumber'
+| 'getInteger'
+| 'getString'
+| 'getChannel'
+| 'getBoolean'
+| 'getSubcommandGroup'
+| 'getSubcommand'
+>;
+
+class ChallengeCreationError extends UserFacingError {
+    constructor(message: string, userMessage: string) {
+        super(message, userMessage);
+        this.name = 'ChallengeCreationError';
+    }
+}
+
+class BatchChallengeCreationError extends UserFacingError {
+    constructor(message: string, userMessage: string) {
+        super(message, userMessage);
+        this.name = 'BatchChallengeCreationError';
+    }
+}
+
+/**
+ * Handles batch creation of one or many Challenge subdocuments within a Tournament. The Factory is
+ * tied to the Tournament (provided by its `ObjectId`) supplied at construction time.
+ */
+class ChallengeFactory {    
+    constructor(private readonly tournamentID: ObjectId) {
+        return;
+    }
+
+    /**
+     * A batch creation method for Challenge subdocuments. In case of duplicates in the batch or
+     * existing Challenges, the method will throw `BatchChallengeCreationError` and no Challenges
+     * will be created.
+     * @param challenges An array of ChallengeModel objects to be created and added to the Tournament.
+     * @returns An array of TournamentDocuments. Since order isn't guaranteed and since batch
+     * creation fails or succeeds together, the return value isn't useful outside of `await`ing completion
+     * completion in calling code.
+     */
+    public async createChallenges(challenges: ChallengeDocument[]): Promise<(TournamentDocument | null)[]> {
+        const singular = challenges.length === 1;
+        const tournamentDocument = await getTournamentById(this.tournamentID);
+        if (!tournamentDocument) throw new ChallengeCreationError(`Tournament with ID ${this.tournamentID} does not exist.`, `The challenge${singular ? ' was' : 's were'} not added. The tournament does not exist.`);
+
+        // Check for duplicate challenge names both in the batch and in the existing challenges.
+        challenges.forEach((newChallenge: Challenge) => {
+            if (tournamentDocument.challenges.includes(newChallenge))
+                throw new BatchChallengeCreationError(`Challenge ${newChallenge.name} already exists in tournament ${tournamentDocument.name}.`,
+                    `The challenge${singular ? ' was' : 's were'} not added. A challenge with the name ${newChallenge.name} already exists in tournament **${tournamentDocument.name}**.`);
+            if (challenges.filter((c: Challenge) => c.name === newChallenge.name).length > 1)
+                throw new BatchChallengeCreationError(`Duplicate challenge names ${newChallenge.name} found in batch.`,
+                    `The challenge${singular ? '' : 's'} were not added. Duplicate challenge names were found in the batch.`);
+        });
+
+        // No duplicates exist, so we are safe to add challenges in any order. 
+        // Since our backend query methods are meant to mimic (simple) API endpoints, no batch
+        // creation method exists (yet), so we must add each challenge individually.
+        const promises = new Array<Promise<TournamentDocument | null>>();
+        challenges.forEach(async (challenge: ChallengeDocument) => {
+            promises.push(addChallengeToTournament(tournamentDocument, challenge));
+        });
+        return Promise.all(promises);
+    }
+}
+
+/**
+ * A class that handles the creation of Challenge subdocuments within a Tournament. It serves as a
+ * wrapper around `ChallengeFactory` to simplify the creation of a single Challenge.
+ * `ChallengeCreator`'s internals may resemble the Factory pattern at a glance, but this is merely
+ * for readability. The class should not be used to create multiple Challenges.
+ */
+class ChallengeCreator {
+    private readonly tournamentName: string;
+    private readonly name: string;
+    private readonly description: string;
+    private readonly game: string;
+    private readonly difficulty: string;
+    private readonly visible: boolean;
+    private currentTournament: Promise<TournamentDocument | null>;
+
+    constructor(private readonly guildID: string, options: CommandInteractionOptionResolverAlias) {
+        this.tournamentName = options.get('tournament', false)?.value as string ?? '';
+        this.name = options.get('name', true).value as string;
+        this.description = options.get('description', true).value as string;
+        this.game = options.get('game', true).value as string;
+        this.difficulty = options.get('difficulty', false)?.value as string ?? '';
+        this.visible = options.get('visible', false)?.value as boolean ?? true;
+        this.currentTournament = getCurrentTournament(this.guildID);
+    }
+
+    async createChallenge(): Promise<void> {
+        // Use the specified tournament if provided. Otherwise attempt to use the current tournament, failing if there is none.
+        let tournament: TournamentDocument | null;
+        if (this.tournamentName) {
+            // A tournament was specified -- use it
+            tournament = await getTournamentByName(this.guildID, this.tournamentName);
+            if (!tournament) throw new ChallengeCreationError(`Tournament ${this.tournamentName} not found in guild ${this.guildID}.`, `That tournament, **${this.tournamentName}**, was not found.`);
+        } else {
+            // No tournament was specified...
+            if (await this.currentTournament) {
+                // ... and there is a current tournament -- use it
+                tournament = await this.currentTournament;
+
+            } else {
+                // ... and there is no current tournament -- fail
+                throw new ChallengeCreationError(`Guild ${this.guildID} has no current tournament.`, 'There is no current tournament. Make sure there is one, or specify your non-active tournament.');
+            }
+        }
+
+        // Validate the difficulty, if provided
+        let difficultyDocument: DifficultyDocument | null = null;
+        if (this.difficulty) {
+            difficultyDocument = await getDifficultyByEmoji(tournament!, this.difficulty);
+            if (!difficultyDocument) throw new ChallengeCreationError(`Difficulty ${this.difficulty} not found in tournament ${this.tournamentName}`, `The challenge was not created. The difficulty you chose, ${this.difficulty}, does not exist in the tournament **${this.tournamentName}**. Remember that difficulties are identified by single emojis.`);
+        }
+        
+        await new ChallengeFactory(tournament!._id).createChallenges([await ChallengeModel.create({
+            name: this.name,
+            description: this.description,
+            game: this.game,
+            difficulty: difficultyDocument,
+            visibility: this.visible,
+        })]);
+    }
+}
+
+const CreateChallengeCommand = new CustomCommand(
+    new SlashCommandBuilder()
+        .setName('create-challenge')
+        .setDescription('Create a challenge.')
+        .addStringOption(option => option.setName('name').setDescription(`A short name for the challenge.`).setRequired(true))
+        .addStringOption(option => option.setName('game').setDescription('The name of the game, or something else like "IRL".').setRequired(true))
+        .addStringOption(option => option.setName('description').setDescription('The complete description of the challenge, restrictions, and rules.').setRequired(true))
+        .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is part of. Defaults to current tournament.').setRequired(false))
+        .addStringOption(option => option.setName('difficulty').setDescription('The emoji representing the challenge level. Defaults to default difficulty.').setRequired(false))
+        .addBooleanOption(option => option.setName('visible').setDescription('Whether the challenge is visible to contestants. Defaults true.').setRequired(false)) as SlashCommandBuilder,
+    async (interaction: CommandInteraction) => {
+        // TODO: Privileges check
+
+
+        try {
+            await new ChallengeCreator(interaction.guildId!, interaction.options).createChallenge();
+            interaction.reply({ content: `✅ Challenge created!`, ephemeral: true });
+        } catch (err) {
+            if (err instanceof UserFacingError) {
+                interaction.reply({ content: `❌ ${err.userMessage}`, ephemeral: true });
+                return;
+            } else if (err instanceof DuplicateSubdocumentError) { // TODO: refactor this logic to have a UserFacingError thrown that provides this message
+                console.error(err); // TODO delete
+                interaction.reply({ content: `❌ The challenge was not created. A challenge with that name already exists in the tournament.`, ephemeral: true });
+                return;
+            }
+            console.error(`Error in create-challenge.ts: ${err}`);
+            interaction.reply({ content: `❌ There was an error while creating the challenge!`, ephemeral: true });
+            return;
+        }
+    }
+);
+
+export default CreateChallengeCommand;

--- a/src/commands/create-challenge.ts
+++ b/src/commands/create-challenge.ts
@@ -168,7 +168,6 @@ const CreateChallengeCommand = new CustomCommand(
                 interaction.reply({ content: `❌ ${err.userMessage}`, ephemeral: true });
                 return;
             } else if (err instanceof DuplicateSubdocumentError) { // TODO: refactor this logic to have a UserFacingError thrown that provides this message
-                console.error(err); // TODO delete
                 interaction.reply({ content: `❌ The challenge was not created. A challenge with that name already exists in the tournament.`, ephemeral: true });
                 return;
             }

--- a/src/types/customDocument.ts
+++ b/src/types/customDocument.ts
@@ -2,12 +2,12 @@ import { ObjectId } from 'mongodb';
 import { Document } from 'mongoose';
 import { BeAnObject, IObjectWithTypegooseFunction } from '@typegoose/typegoose/lib/types.js';
 import { Tournament } from '../backend/schemas/tournament.js';
-import { Submission } from 'src/backend/schemas/submission.js';
-import { Challenge } from 'src/backend/schemas/challenge.js';
-import { Difficulty } from 'src/backend/schemas/difficulty.js';
-import { Judge } from 'src/backend/schemas/judge.js';
-import { GuildSettings } from 'src/backend/schemas/guildsettings.js';
-import { Contestant } from 'src/backend/schemas/contestant.js';
+import { Challenge } from '../backend/schemas/challenge.js';
+import { Contestant } from '../backend/schemas/contestant.js';
+import { Difficulty } from '../backend/schemas/difficulty.js';
+import { GuildSettings } from '../backend/schemas/guildsettings.js';
+import { Judge } from '../backend/schemas/judge.js';
+import { Submission } from '../backend/schemas/submission.js';
 
 type GenericDocument<T> = Document<ObjectId, BeAnObject, T> & Omit<T & Required<{ _id: ObjectId; }>, 'typegooseName'> & IObjectWithTypegooseFunction;
 export type TournamentDocument = GenericDocument<Tournament>;

--- a/src/types/customDocument.ts
+++ b/src/types/customDocument.ts
@@ -1,0 +1,19 @@
+import { ObjectId } from 'mongodb';
+import { Document } from 'mongoose';
+import { BeAnObject, IObjectWithTypegooseFunction } from '@typegoose/typegoose/lib/types.js';
+import { Tournament } from '../backend/schemas/tournament.js';
+import { Submission } from 'src/backend/schemas/submission.js';
+import { Challenge } from 'src/backend/schemas/challenge.js';
+import { Difficulty } from 'src/backend/schemas/difficulty.js';
+import { Judge } from 'src/backend/schemas/judge.js';
+import { GuildSettings } from 'src/backend/schemas/guildsettings.js';
+import { Contestant } from 'src/backend/schemas/contestant.js';
+
+type GenericDocument<T> = Document<ObjectId, BeAnObject, T> & Omit<T & Required<{ _id: ObjectId; }>, 'typegooseName'> & IObjectWithTypegooseFunction;
+export type TournamentDocument = GenericDocument<Tournament>;
+export type SubmissionDocument = GenericDocument<Submission>;
+export type ChallengeDocument = GenericDocument<Challenge>;
+export type DifficultyDocument = GenericDocument<Difficulty>;
+export type JudgeDocument = GenericDocument<Judge>;
+export type GuildSettingsDocument = GenericDocument<GuildSettings>;
+export type ContestantDocument = GenericDocument<Contestant>;

--- a/src/types/customError.ts
+++ b/src/types/customError.ts
@@ -4,3 +4,36 @@ export class DuplicateSubdocumentError extends Error {
         this.name = 'DuplicateSubdocumentError';
     }
 }
+
+/**
+ * This error is currently unused in the codebase. In most use cases, it is preferable to use the 
+ * getOrCreateGuildSettings() function rather than throw and/or handle this error manually.
+ */
+export class NonexistentGuildError extends Error {
+    constructor(public guildID: string) {
+        super(`Guild with ID ${guildID} does not exist in the database.`);
+        this.name = 'NonexistentGuildError';
+    }
+}
+
+/**
+ * For error handling near user-facing code, this abstract class provides an additional property 
+ * `userMessage` extending classes can use to provide a response to the user's slash command
+ * indicating what went wrong.
+ */
+export abstract class UserFacingError extends Error {
+    constructor(message: string, public readonly userMessage: string) {
+        super(message);
+        this.name = 'UserFacingError';
+    }
+}
+
+/**
+ * A 'base' `UserFacingError` class for errors that do not have a specific type.
+ */
+export class UserMessageError extends UserFacingError {
+    constructor(message: string, userMessage: string) {
+        super(message, userMessage);
+        this.name = 'UserMessageError';
+    }
+}

--- a/src/util/commandHandler.ts
+++ b/src/util/commandHandler.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { pathToFileURL, fileURLToPath } from 'url';
-import { TournamentionClient } from 'src/types/client';
-import { CustomCommand } from 'src/types/customCommand';
+import { TournamentionClient } from '../types/client';
+import { CustomCommand } from '../types/customCommand';
 
 export const prepareCommands = async (client: TournamentionClient) => {
     const commandsPath = pathToFileURL(path.join(process.cwd(), './src/commands'));

--- a/src/util/eventHandler.ts
+++ b/src/util/eventHandler.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
-import { TournamentionClient } from 'src/types/client.js';
-import { CustomEvent } from 'src/types/customEvent.js';
 import { pathToFileURL, fileURLToPath } from 'url';
+import { TournamentionClient } from '../types/client';
+import { CustomEvent } from '../types/customEvent';
 
 export const prepareEvents = async (client: TournamentionClient) => {
     const eventsPath = pathToFileURL(path.join(process.cwd(), './src/events'));


### PR DESCRIPTION
A slash command to create new challenges is the only new user-facing feature, but this also includes new frameworks for error handling and typechecking. 

Closes #14. Work will continue on the branch.

Creating challenges is accomplished through a `ChallengeFactory` Factory-pattern class, which supports batch challenge creation, and a `ChallengeCreator` wrapper/adapter class. `ChallengeCreator` has a Factory-esque interface but is merely a simple way of creating challenges based on the data inputted through the /create-challenge slash command. `ChallengeFactory` was written as such to allow batch creation in the future: e.g. I had the ability to copy over all challenges from an old Tournament to a new one in mind. Is it premature abstraction? Maybe. But it's good practice and best practice 😉

For now, the backend query methods only support single challenge creation calls and `ChallengeFactory` handles all the validation you'd expect. As noted, I designed these backend query methods to mimic API endpoints, so the class simply makes many concurrent calls to create individual challenges when performing batch operations. Batch operation endpoints exist, of course, but I'm keeping it simple for now. There is the possibility of concurrency issues with batch challenge creation, but that would be a problem in the query method, not the calling code. That's beyond the scope of this feature branch, anyway.

The error handling feature is quite simple and useful and I'm surprised we didn't do something like it earlier. An abstract class `UserFacingError` adds a `userMessage` property to `Error` which objects of extending classes can use to provide specific feedback to the end-user as to why their slash command failed. Handling logic can then check for instance of `UserFacingError` and display the specific response rather than the default "There was an error while performing this command!" or some intermediate messaging approach we used previously. I'm quite happy with the benefits this will have for slash commands, but I'm unsure how exactly it will be relevant with the fancier kinds of application commands we wanted to try using. 

I provide a few useful type aliases (I think I'm using that term correctly?) for MongoDB Documents of our various models and slash command options. I have also explicitly given backend query methods return types (often from these new type aliases) to simplify understanding of their usage. Yes, I consider this documentation.

Lastly, a simple backend query method that gets a GuildSettings document or creates one if one does not exist has been added. In the Condemned Souls bot we required server admins to first run a designated command /guildjoin that would, among other things, create the document for the server. I really didn't like doing this from a UX standpoint -- more barriers to entry for no obvious benefit -- but it wasn't my responsibility and with some mental gymnastics and tacked-on features we justified it. No longer! Users will seamlessly have their server setup upon first use of the relevant commands.

Miscellaneous changes:
- difficulty is no longer required on Challenge, since null should refer to the default difficulty. I made the mistake of trusting an LLM, but no, null is not considered a sufficient field value when `required: true` is set in the schema
- Changed linter config to ignore generated files and dependencies