### PR TITLE
Add edit-tournament command, fix bug and typo

### DIFF
--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -4,6 +4,7 @@ import { Tournament, TournamentModel } from '../schemas/tournament.js';
 import { DuplicateSubdocumentError, UserMessageError } from '../../types/customError.js';
 import { Difficulty, DifficultyModel } from '../schemas/difficulty.js';
 import { ChallengeDocument, DifficultyDocument, TournamentDocument } from '../../types/customDocument.js';
+import { UpdateTournamentParams } from '../../types/apiPayloadObjects.js';
 
 // CREATE / POST
 export const createTournament = async (guildID: string, name: string, photoURI: string, active: boolean, statusDescription: string, visibility: boolean, duration: string): Promise<TournamentDocument> => {
@@ -113,28 +114,7 @@ export const getDifficultyByEmoji = async (tournament: TournamentDocument, emoji
 };
 
 // UPDATE / PUT
-interface UpdateTournamentParams {
-    name?: string;
-    photoURI?: string;
-    active?: boolean;
-    statusDescription?: string;
-    visibility?: boolean;
-    duration?: string;
-}
-
-export const updateTournament = async (id: ObjectId, newName?: string, photoURI?: string, visibility?: boolean, active?: boolean, statusDescription?: string, duration?: string): Promise<TournamentDocument | null> => {
-    // TODO: This method is quite messy. Calling code (eg. edit-tournament.ts) should be refactored to exclude unnecessary parameters.
-    // Recall before refactoring that this method is meant to 
-    // (1) mimic an API endpoint
-    // (2) manipulate some object for the Mongoose $set operator (which isn't quite so simple in TS).
-    const update: UpdateTournamentParams = {};
-    if (newName !== null && newName !== undefined) update.name = newName;
-    if (photoURI !== null && photoURI !== undefined) update.photoURI = photoURI;
-    if (active !== null && active !== undefined) update.active = active;
-    if (statusDescription !== null && statusDescription !== undefined) update.statusDescription = statusDescription;
-    if (visibility !== null && visibility !== undefined) update.visibility = visibility;
-    if (duration !== null && duration !== undefined) update.duration = duration;
-
+export const updateTournament = async (id: ObjectId, update: UpdateTournamentParams): Promise<TournamentDocument | null> => {
     return TournamentModel.findByIdAndUpdate(id, { $set: update });
 };
 

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -122,14 +122,18 @@ interface UpdateTournamentParams {
     duration?: string;
 }
 
-export const updateTournament = async (id: Ref<Tournament>, name?: string, photoURI?: string, active?: boolean, statusDescription?: string, visibility?: boolean, duration?: string): Promise<TournamentDocument | null> => {
+export const updateTournament = async (id: ObjectId, newName?: string, photoURI?: string, visibility?: boolean, active?: boolean, statusDescription?: string, duration?: string): Promise<TournamentDocument | null> => {
+    // TODO: This method is quite messy. Calling code (eg. edit-tournament.ts) should be refactored to exclude unnecessary parameters.
+    // Recall before refactoring that this method is meant to 
+    // (1) mimic an API endpoint
+    // (2) manipulate some object for the Mongoose $set operator (which isn't quite so simple in TS).
     const update: UpdateTournamentParams = {};
-    if (name !== undefined) update.name = name;
-    if (photoURI !== undefined) update.photoURI = photoURI;
-    if (active !== undefined) update.active = active;
-    if (statusDescription !== undefined) update.statusDescription = statusDescription;
-    if (visibility !== undefined) update.visibility = visibility;
-    if (duration !== undefined) update.duration = duration;
+    if (newName !== null && newName !== undefined) update.name = newName;
+    if (photoURI !== null && photoURI !== undefined) update.photoURI = photoURI;
+    if (active !== null && active !== undefined) update.active = active;
+    if (statusDescription !== null && statusDescription !== undefined) update.statusDescription = statusDescription;
+    if (visibility !== null && visibility !== undefined) update.visibility = visibility;
+    if (duration !== null && duration !== undefined) update.duration = duration;
 
     return TournamentModel.findByIdAndUpdate(id, { $set: update });
 };

--- a/src/commands/create-challenge.ts
+++ b/src/commands/create-challenge.ts
@@ -122,7 +122,7 @@ class ChallengeCreator {
             name: this.name,
             description: this.description,
             game: this.game,
-            difficulty: difficultyDocument!._id,
+            difficulty: (difficultyDocument ? difficultyDocument._id : difficultyDocument),
             visibility: this.visible,
         })]);
     }

--- a/src/commands/create-tournament.ts
+++ b/src/commands/create-tournament.ts
@@ -4,7 +4,7 @@ import { CommandInteraction } from 'discord.js';
 import { CustomCommand } from '../types/customCommand.js';
 import { TournamentBuilder } from '../backend/queries/tournamentQueries.js';
 
-const InfoCommand = new CustomCommand(
+const CreateTournamentCommand = new CustomCommand(
     new SlashCommandBuilder()
         .setName('create-tournament')
         .setDescription('Create a new tournament from scratch.')
@@ -46,4 +46,4 @@ const InfoCommand = new CustomCommand(
     }
 );
 
-export default InfoCommand;
+export default CreateTournamentCommand;

--- a/src/commands/edit-tournament.ts
+++ b/src/commands/edit-tournament.ts
@@ -1,0 +1,73 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction } from 'discord.js';
+import { CustomCommand } from '../types/customCommand.js';
+import { UserFacingError } from '../types/customError.js';
+import { getTournamentByName, updateTournament } from '../backend/queries/tournamentQueries.js';
+import { CommandInteractionOptionResolverAlias } from '../types/discordTypeAlias.js';
+import { TournamentDocument } from '../types/customDocument.js';
+
+class EditTournamentError extends UserFacingError {
+    constructor(message: string, userMessage: string) {
+        super(message, userMessage);
+        this.name = 'EditTournamentError';
+    }
+}
+
+/**
+ * Performs the entire editing process on a Tournament.
+ * @param guildID `interaction.guildId`
+ * @param options `interaction.options`
+ * @returns The updated TournamentDocument, or null if the `updateTournament` call failed, which would only happen in a hypothetically possible race condition.
+ * @throws `EditTournamentError` if the Tournament is not found by name.
+ */
+const editTournament = async (guildID: string, options: CommandInteractionOptionResolverAlias): Promise<TournamentDocument | null> => {
+    const name = options.get('name', true).value as string;
+    const newName = options.get('new-name', false)?.value as string ?? null;
+    const photoURI = options.get('photo-uri', false)?.value as string ?? null;
+    const visible = options.get('visible', false)?.value as boolean ?? null;
+    const active = options.get('active', false)?.value as boolean ?? null;
+    const statusDescription = options.get('status-description', false)?.value as string ?? null;
+    const duration = options.get('duration', false)?.value as string ?? null;
+
+    const tournament = await getTournamentByName(guildID, name);
+    if (!tournament) throw new EditTournamentError(`Tournament ${name} not found in guild ${guildID}.`, `That tournament, **${name}**, was not found.`);
+    return updateTournament(
+        tournament._id, 
+        (newName ? newName : tournament.name),
+        (photoURI ? photoURI : tournament.photoURI),
+        ((visible !== null) ? visible : tournament.visibility), 
+        ((active !== null) ? active : tournament.active), 
+        (statusDescription ? statusDescription : tournament.statusDescription), 
+        (duration ? duration : tournament.duration)
+    );
+};
+
+const EditTournamentCommand = new CustomCommand(
+    new SlashCommandBuilder()
+        .setName('edit-tournament')
+        .setDescription('Edit the details of a Tournament.')
+        .addStringOption(option => option.setName('name').setDescription('The name of the tournament.').setRequired(true))
+        .addStringOption(option => option.setName('new-name').setDescription('Rename the tournament to this.').setRequired(false))
+        .addStringOption(option => option.setName('photo-uri').setDescription(`Change the linked image for the tournament's thumbnail.`).setRequired(false))
+        .addBooleanOption(option => option.setName('visible').setDescription('Change whether the tournament can be seen by non-judges.').setRequired(false))
+        .addBooleanOption(option => option.setName('active').setDescription('Change whether the tournament is accepting submissions now.').setRequired(false))
+        .addStringOption(option => option.setName('status-description').setDescription('Change the explanation message for the tournament\'s current status.').setRequired(false))
+        .addStringOption(option => option.setName('duration').setDescription('Change the message for when the tournament takes place.').setRequired(false)) as SlashCommandBuilder,
+    async (interaction: CommandInteraction) => {
+        // TODO: Privileges check
+
+        try {
+            if (!(await editTournament(interaction.guildId!, interaction.options))) throw new Error(`editTournament returned null.`);
+            interaction.reply({ content: `✅ Tournament updated!`, ephemeral: true });
+        } catch (err) {
+            if (err instanceof UserFacingError) {
+                interaction.reply({ content: `❌ ${err.userMessage}`, ephemeral: true });
+                return;
+            }
+            console.error(`Error in edit-tournament.ts: ${err}`);
+            interaction.reply({ content: `❌ There was an error while updating the tournament!`, ephemeral: true });
+        }
+    }
+);
+
+export default EditTournamentCommand;

--- a/src/commands/edit-tournament.ts
+++ b/src/commands/edit-tournament.ts
@@ -33,12 +33,15 @@ const editTournament = async (guildID: string, options: CommandInteractionOption
     if (!tournament) throw new EditTournamentError(`Tournament ${name} not found in guild ${guildID}.`, `That tournament, **${name}**, was not found.`);
     return updateTournament(
         tournament._id, 
-        (newName ? newName : tournament.name),
-        (photoURI ? photoURI : tournament.photoURI),
-        ((visible !== null) ? visible : tournament.visibility), 
-        ((active !== null) ? active : tournament.active), 
-        (statusDescription ? statusDescription : tournament.statusDescription), 
-        (duration ? duration : tournament.duration)
+        // Conditionally add properties to the object. It would be almost equivalent to assign some but with the value undefined
+        {
+            ...(newName && { name: newName }),
+            ...(photoURI && { photoURI: photoURI }),
+            ...(active !== null && { active: active }),
+            ...(visible !== null && { visibility: visible }),
+            ...(statusDescription && { statusDescription: statusDescription }),
+            ...(duration && { duration: duration }),
+        }
     );
 };
 

--- a/src/types/apiPayloadObjects.ts
+++ b/src/types/apiPayloadObjects.ts
@@ -1,0 +1,11 @@
+/**
+ * Includes all parameters that can be updated in a Tournament.
+ */
+export interface UpdateTournamentParams {
+    name?: string;
+    photoURI?: string;
+    active?: boolean;
+    statusDescription?: string;
+    visibility?: boolean;
+    duration?: string;
+}


### PR DESCRIPTION
I don't tend to do this but the commit messages describe everything that needs to be said for this pretty straightforward PR.

The upcoming edit-challenge will be very similar to edit-tournament. It doesn't have much fancy code going on compared to the last few commands because I don't think it needs it. I will point out that this is the first backend method that takes a JSON object with some subset of available properties and values to be used as the update parameters, which is more akin to how an API endpoint would accept these requests. As such it is perhaps something to strive for in prior and upcoming code.