### PR TITLE
Add edit-challenge. Refactor out nested documents

### DIFF
--- a/src/backend/queries/challengeQueries.ts
+++ b/src/backend/queries/challengeQueries.ts
@@ -1,7 +1,16 @@
+import { ObjectId } from 'mongodb';
+import { ChallengeDocument } from '../../types/customDocument.js';
+import { ChallengeModel } from '../schemas/challenge.js';
+import { UpdateChallengeParams } from '../../types/apiPayloadObjects.js';
 // CREATE / POST
 
 // READ / GET
 
 // UPDATE / PUT
+// const updateChallengeByName = async (challenge)
+
+export const updateChallengeById = async (id: ObjectId, update: UpdateChallengeParams): Promise<ChallengeDocument | null> => {
+    return ChallengeModel.findByIdAndUpdate(id, { $set: update });
+};
 
 // DELETE

--- a/src/backend/queries/submissionQueries.ts
+++ b/src/backend/queries/submissionQueries.ts
@@ -1,8 +1,7 @@
-import { ReviewNoteModel, Submission, SubmissionModel, SubmissionStatus } from '../schemas/submission';
+import { Submission, SubmissionModel } from '../schemas/submission';
 import { Ref } from '@typegoose/typegoose';
 import { Challenge } from '../schemas/challenge';
 import { Contestant } from '../schemas/contestant';
-import { Judge } from '../schemas/judge';
 
 // CREATE / POST
 export const createSubmission = async (challengeID: Ref<Challenge>, contestantID: Ref<Contestant>, proof: string) => {
@@ -27,12 +26,13 @@ export const getSubmissionsForChallenge = async (challengeID: Ref<Challenge>) =>
 };
 
 // UPDATE / PUT
-export const addReviewNoteToSubmission = async (submission: Ref<Submission>, judgeID: Ref<Judge>, note: string, reviewStatus: SubmissionStatus) => {
-    return SubmissionModel.findOneAndUpdate({ _id: submission}, {
-        $push: {
-            reviewNotes: new ReviewNoteModel({ judgeID: judgeID, note: note, status: reviewStatus }),
-        }
-    });
-};
+// TODO: Use refs instead of nested documents (#37)
+// export const addReviewNoteToSubmission = async (submission: Ref<Submission>, judgeID: Ref<Judge>, note: string, reviewStatus: SubmissionStatus) => {
+//     return SubmissionModel.findOneAndUpdate({ _id: submission}, {
+//         $push: {
+//             reviewNotes: new ReviewNoteModel({ judgeID: judgeID, note: note, status: reviewStatus }),
+//         }
+//     });
+// };
 
 // DELETE

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -105,7 +105,7 @@ export const getDifficultyByID = async (id: ObjectId): Promise<DifficultyDocumen
 
 export const getDifficultyByEmoji = async (tournament: TournamentDocument, emoji: string): Promise<DifficultyDocument | null> => {
     if (!isSingleEmoji(emoji)) throw new UserMessageError(`Supplied emoji string ${emoji} is invalid`, `Difficulty must be a single emoji. You used: ${emoji}`);
-    const resolvedDifficulties = await DifficultyModel.find({ _id: { $in: tournament.difficulties } }) as DifficultyDocument[];
+    const resolvedDifficulties = await tournament.get('resolvingDifficulties') as DifficultyDocument[];
     if (!resolvedDifficulties) throw new Error(`Error in tournamentQueries.ts: Could not get difficulties for tournament ${tournament._id}`);
     for (const difficulty of resolvedDifficulties) {
         if (difficulty.emoji === emoji) {

--- a/src/backend/schemas/tournament.ts
+++ b/src/backend/schemas/tournament.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
-import { prop, index, getModelForClass } from '@typegoose/typegoose';
-import { Challenge } from './challenge.js';
-import { Difficulty } from './difficulty.js';
+import { prop, index, getModelForClass, Ref } from '@typegoose/typegoose';
+import { Challenge, ChallengeModel } from './challenge.js';
+import { Difficulty, DifficultyModel } from './difficulty.js';
 
 @index({ guildID: 1, name: 1 }, { unique: true })
 export class Tournament {
@@ -28,11 +28,21 @@ export class Tournament {
     @prop({ required: true })
     public duration!: string;
 
-    @prop({ required: true, type: () => [Challenge], default: [] })
-    public challenges!: Challenge[];
+    @prop({ required: true, ref: () => Challenge, type: () => [Challenge], default: [] })
+    public challenges!: Ref<Challenge>[];
 
-    @prop({ required: true, type: () => [Difficulty], default: [] })
-    public difficulties!: Difficulty[];
+    @prop({ required: true, ref: () => Difficulty, type: () => [Difficulty], default: [] })
+    public difficulties!: Ref<Difficulty>[];
 }
 
 export const TournamentModel = getModelForClass(Tournament);
+
+TournamentModel.schema.virtual('resolvingChallenges').get(function() {
+    // If this doesn't work then try returning the promise and rename this resolvingChallenges
+    return ChallengeModel.find({ _id: { $in: this.challenges } });
+});
+
+TournamentModel.schema.virtual('resolvingDifficulties').get(function() {
+    // If this doesn't work then try returning the promise and rename this resolvingDifficulties
+    return DifficultyModel.find({ _id: { $in: this.difficulties } });
+});

--- a/src/commands/create-challenge.ts
+++ b/src/commands/create-challenge.ts
@@ -47,8 +47,8 @@ class ChallengeFactory {
         if (!tournamentDocument) throw new ChallengeCreationError(`Tournament with ID ${this.tournamentID} does not exist.`, `The challenge${singular ? ' was' : 's were'} not added. The tournament does not exist.`);
 
         // Check for duplicate challenge names both in the batch and in the existing challenges.
-        challenges.forEach((newChallenge: Challenge) => {
-            if (tournamentDocument.challenges.includes(newChallenge))
+        challenges.forEach(async (newChallenge: Challenge) => {
+            if ((await tournamentDocument.get('resolvingChallenges')).includes(newChallenge))
                 throw new BatchChallengeCreationError(`Challenge ${newChallenge.name} already exists in tournament ${tournamentDocument.name}.`,
                     `The challenge${singular ? ' was' : 's were'} not added. A challenge with the name ${newChallenge.name} already exists in tournament **${tournamentDocument.name}**.`);
             if (challenges.filter((c: Challenge) => c.name === newChallenge.name).length > 1)

--- a/src/commands/create-difficulty.ts
+++ b/src/commands/create-difficulty.ts
@@ -43,8 +43,8 @@ class DifficultyFactory {
         if (!tournamentDocument) throw new DifficultyCreationError(`Tournament with ID ${this.tournamentID} does not exist.`, `The difficult${singular ? 'y was' : 'ies were'} not added. The tournament does not exist.`);
 
         // Check for duplicate difficulty emojis both in the batch and in the existing challenges.
-        difficulties.forEach((newDifficulty: Difficulty) => {
-            if (tournamentDocument.difficulties.includes(newDifficulty))
+        difficulties.forEach(async (newDifficulty: Difficulty) => {
+            if ((await tournamentDocument.get('resolvingDifficulties')).includes(newDifficulty))
                 throw new BatchDifficultyCreationError(`Challenge ${newDifficulty.emoji} already exists in tournament ${tournamentDocument.name}.`,
                     `The difficult${singular ? 'y was' : 'ies were'} not added. A difficulty with the emoji ${newDifficulty.emoji} already exists in tournament **${tournamentDocument.name}**.`);
             if (difficulties.filter((d: Difficulty) => d.emoji === newDifficulty.emoji).length > 1)

--- a/src/commands/edit-challenge.ts
+++ b/src/commands/edit-challenge.ts
@@ -1,0 +1,105 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction } from 'discord.js';
+import { CustomCommand } from '../types/customCommand.js';
+import { UserFacingError } from '../types/customError.js';
+import { getTournamentByName } from '../backend/queries/tournamentQueries.js';
+import { CommandInteractionOptionResolverAlias } from '../types/discordTypeAlias.js';
+import { ChallengeDocument, TournamentDocument } from '../types/customDocument.js';
+import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
+import { updateChallengeById } from '../backend/queries/challengeQueries.js';
+import { Difficulty } from '../backend/schemas/difficulty.js';
+
+class EditChallengeError extends UserFacingError {
+    constructor(message: string, userMessage: string) {
+        super(message, userMessage);
+        this.name = 'EditTournamentError';
+    }
+}
+
+/**
+ * Performs the entire editing process on a Challenge.
+ * @param guildID `interaction.guildId`
+ * @param options `interaction.options`
+ * @returns The updated ChallengeDocument, or null if the `updateChallenge` call failed, which would only happen in a hypothetically possible race condition.
+ * @throws `EditChallengeError` if the Tournament is not found by name.
+ */
+const editChallenge = async (guildID: string, options: CommandInteractionOptionResolverAlias): Promise<ChallengeDocument | null> => {
+    const name = options.get('name', true).value as string;
+    const tournamentName = options.get('tournament', false)?.value as string ?? null;
+    const newName = options.get('new-name', false)?.value as string ?? null;
+    const description = options.get('description', false)?.value as string ?? null;
+    const difficulty = options.get('difficulty', false)?.value as string ?? null;
+    const game = options.get('game', false)?.value as string ?? null;
+    const visible = options.get('visible', false)?.value as boolean ?? null;
+
+    // Resolve desired tournament
+    let tournament: TournamentDocument | null;
+    if (tournamentName)  {
+        // A tournament was specified -- use it
+        tournament = await getTournamentByName(guildID, tournamentName);
+        if (!tournament) throw new EditChallengeError(`Tournament ${tournamentName} not found in guild ${guildID}.`, `That tournament, **${tournamentName}**, was not found.`);
+    } else {
+        // No tournament was specified...
+        const currentTournament = await getCurrentTournament(guildID);
+        if (currentTournament) {
+            // ... and there is a current tournament -- use it
+            tournament = currentTournament;
+        } else {
+            // ... and there is no current tournament -- fail
+            throw new EditChallengeError(`Guild ${guildID} has no current tournament.`, 'There is no current tournament. Make sure there is one, or specify your non-active tournament.');
+        }
+    }
+
+    // Resolve desired challenge
+    const challenge = tournament.challenges.find(challenge => challenge.name === name);
+    if (!challenge) throw new EditChallengeError(`Challenge ${name} not found in tournament ${tournamentName}.`, `That challenge, **${name}**, was not found in the tournament **${tournamentName}**.`);
+
+    // Resolve desired difficulty
+    let difficultyObject: Difficulty | undefined;
+    if (difficulty) {
+        difficultyObject = await tournament.difficulties.find(difficultyDocument => difficultyDocument.emoji === difficulty);
+        if (!difficultyObject) throw new EditChallengeError(`Difficulty ${difficulty} not found in tournament ${tournamentName}`, `The challenge was not edited. The difficulty you chose, ${difficulty}, does not exist in the tournament **${tournamentName}**. Remember that difficulties are identified by single emojis.`);
+    }
+    console.log(`${difficulty} ${difficultyObject} ${challenge._id}`);
+
+    return updateChallengeById(
+        challenge._id,
+        {
+            ...(newName && { name: newName }),
+            ...(description && { description: description }),
+            ...((difficulty && difficultyObject) && { difficulty: difficultyObject._id }),
+            ...(game && { game: game }),
+            ...(visible !== null && { visibility: visible }),
+        }
+    );
+};
+
+const EditChallengeCommand = new CustomCommand(
+    new SlashCommandBuilder()
+        .setName('edit-challenge')
+        .setDescription('Edit the details of a Challenge.')
+        .addStringOption(option => option.setName('name').setDescription('The name of the challenge.').setRequired(true))
+        .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is in. Defaults to current tournament.').setRequired(false))
+        .addStringOption(option => option.setName('new-name').setDescription('Rename the challenge to this.').setRequired(false))
+        .addStringOption(option => option.setName('description').setDescription('Change the description of the challenge, including restrictions or rules.').setRequired(false))
+        .addStringOption(option => option.setName('difficulty').setDescription(`Change the challenge's difficulty, using the emoji of a difficulty that exists in the tournament.`).setRequired(false))
+        .addStringOption(option => option.setName('game').setDescription('Change the game this challenge is for, or something else like "IRL".').setRequired(false))
+        .addBooleanOption(option => option.setName('visible').setDescription('Change whether the tournament can be seen by non-judges.').setRequired(false)) as SlashCommandBuilder,
+    async (interaction: CommandInteraction) => {
+        // TODO: Privileges check
+
+        try {
+            if (!(await editChallenge(interaction.guildId!, interaction.options))) throw new Error(`editChallenge returned null.`);
+            interaction.reply({ content: `✅ Challenge updated!`, ephemeral: true });
+        } catch (err) {
+            if (err instanceof UserFacingError) {
+                interaction.reply({ content: `❌ ${err.userMessage}`, ephemeral: true });
+                return;
+            }
+            console.error(`Error in edit-tournament.ts: ${err}`);
+            interaction.reply({ content: `❌ There was an error while updating the tournament!`, ephemeral: true });
+        }
+    }
+);
+
+export default EditChallengeCommand;

--- a/src/types/apiPayloadObjects.ts
+++ b/src/types/apiPayloadObjects.ts
@@ -1,3 +1,5 @@
+import { ObjectId } from 'mongodb';
+
 /**
  * Includes all parameters that can be updated in a Tournament.
  */
@@ -8,4 +10,12 @@ export interface UpdateTournamentParams {
     statusDescription?: string;
     visibility?: boolean;
     duration?: string;
+}
+
+export interface UpdateChallengeParams {
+    name?: string;
+    description?: string;
+    difficulty?: ObjectId;
+    game?: string;
+    visibility?: boolean;
 }


### PR DESCRIPTION
The command does what you might expect (closes #21), so the most noteworthy change is to the database schema.

I'll briefly mention the motivation: Each Challenge and Difficulty belongs to only one Tournament, so it seemed reasonable to leverage one of the main selling points of a NoSQL database over a relational and have them exist just as subdocuments of Tournament. To ensure each subdocument is, well, a document of the corresponding type, when we add a new subdocument we first create it through the Model. This incidentally adds it to a separate collection (AFAIK it has to be done this way). Neat, I thought, it'll basically work as a separate index for that data! Turns out, changes to one do not get reflected in the other. To avoid confusion and wasted storage space, this was the nail in the coffin for this idea. There are legitimate use cases for nested documents, but ours is not one.

Instead, we now use something closer resembling a relational schema: anywhere we used to use subdocuments, we instead now use references to other documents, accomplished by the Typegoose Ref parameterized type and/or ObjectId. All refactors have been made to restore functionality. 

One of the techniques I used to do this was the Mongoose virtual method. For example, we keep challenges in an array of ObjectId called `challenges`, but meanwhile a virtual getter called `resolvingChallenges` performs the query to translate `challenges` to an array of ChallengeDocument. It's an unusual name convention but it seems you can't have an async function for a virtual method (and you are kind of discouraged from doing queries in a virtual at all -- more on that at the end). You need to await the call in user code:

```js
if ((await tournamentDocument.get('resolvingChallenges')).includes(newChallenge))
```

As a possible alternative to using virtuals in this way, the feature `populate()` exists in Mongoose to do essentially what we want to do. In Typegoose, the [documentation for the feature's support is](https://typegoose.github.io/typegoose/docs/api/virtuals/) much more limited, so I decided to try something else first, which ended up working totally fine. 

Closes #37 which has more commentary.