### PR TITLE
Add /submit-challenge command

### DIFF
--- a/src/backend/queries/challengeQueries.ts
+++ b/src/backend/queries/challengeQueries.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import { ChallengeDocument } from '../../types/customDocument.js';
+import { ChallengeDocument, TournamentDocument } from '../../types/customDocument.js';
 import { ChallengeModel } from '../schemas/challenge.js';
 import { UpdateChallengeParams } from '../../types/apiPayloadObjects.js';
 // CREATE / POST

--- a/src/backend/queries/challengeQueries.ts
+++ b/src/backend/queries/challengeQueries.ts
@@ -5,6 +5,16 @@ import { UpdateChallengeParams } from '../../types/apiPayloadObjects.js';
 // CREATE / POST
 
 // READ / GET
+export const getChallengeById = async (id: ObjectId): Promise<ChallengeDocument | null> => {
+    return ChallengeModel.findById(id);
+};
+
+export const getChallengeOfTournamentByName = async (name: string, tournament: TournamentDocument): Promise<ChallengeDocument | null> => {
+    // Each Tournament aggregates its own Challenges, but Challenges do not know their Tournament.
+    // Use Mongoose's query builder to filter for Challenges with both the matching name and
+    // membership in the tournament's challenge.
+    return ChallengeModel.findOne().where('_id').in(tournament.challenges).where('name').equals(name).exec();
+};
 
 // UPDATE / PUT
 // const updateChallengeByName = async (challenge)

--- a/src/backend/queries/profileQueries.ts
+++ b/src/backend/queries/profileQueries.ts
@@ -1,6 +1,29 @@
+import { ContestantDocument } from '../../types/customDocument.js';
+import { ContestantModel } from '../schemas/contestant.js';
+
 // CREATE / POST
+export const createContestant = async (guildId: string, memberId: string): Promise<ContestantDocument> => {
+    return ContestantModel.create({
+        guildID: guildId,
+        userID: memberId,
+    });
+};
 
 // READ / GET
+/**
+ * Gets or creates a Contestant document. Every Discord member who uses a contestant feature is a Contestant.
+ * However, being a Contestant may not be sufficient for participation in a Tournament; this depends on the
+ * guild's and the Tournament's settings. For this reason, this endpoint can be used for any (well-formed)
+ * app interaction involving a Contestant.
+ * @param guildId The Discord guild ID.
+ * @param memberId The Discord member ID.
+ * @returns The new or existing Contestant document.
+ */
+export const getOrCreateContestant = async (guildId: string, memberId: string): Promise<ContestantDocument> => {
+    const contestant = await ContestantModel.findOne({ guildID: guildId, userID: memberId });
+    if (contestant) return contestant;
+    else return createContestant(guildId, memberId);
+};
 
 // UPDATE / PUT
 

--- a/src/backend/queries/submissionQueries.ts
+++ b/src/backend/queries/submissionQueries.ts
@@ -1,7 +1,7 @@
-import { Submission, SubmissionModel } from '../schemas/submission';
+import { Submission, SubmissionModel } from '../schemas/submission.js';
 import { Ref } from '@typegoose/typegoose';
-import { Challenge } from '../schemas/challenge';
-import { Contestant } from '../schemas/contestant';
+import { Challenge } from '../schemas/challenge.js';
+import { Contestant } from '../schemas/contestant.js';
 
 // CREATE / POST
 export const createSubmission = async (challengeID: Ref<Challenge>, contestantID: Ref<Contestant>, proof: string) => {

--- a/src/backend/queries/submissionQueries.ts
+++ b/src/backend/queries/submissionQueries.ts
@@ -9,6 +9,7 @@ export const createSubmission = async (challengeID: Ref<Challenge>, contestantID
         challengeID: challengeID,
         contestantID: contestantID,
         proof: proof,
+        reviewNotes: [],
     });
 };
 
@@ -23,6 +24,10 @@ export const getSubmissionsFromContestant = async (contestantID: Ref<Contestant>
 
 export const getSubmissionsForChallenge = async (challengeID: Ref<Challenge>) => {
     return SubmissionModel.find({ challengeID: challengeID });
+};
+
+export const getSubmissionsForChallengeFromContestant = async (challengeId: Ref<Challenge>, contestantId: Ref<Contestant>) => {
+    return SubmissionModel.find({ challengeID: challengeId, contestantID: contestantId });
 };
 
 // UPDATE / PUT

--- a/src/backend/schemas/contestant.ts
+++ b/src/backend/schemas/contestant.ts
@@ -1,7 +1,10 @@
 import { prop, index, getModelForClass } from '@typegoose/typegoose';
+import { ObjectId } from 'mongodb';
 
 @index({ userID: 1, guildID: 1 }, { unique: true })
 export class Contestant {
+    _id!: ObjectId;
+
     @prop({ required: true })
     public userID!: string;
 

--- a/src/commands/submit-challenge.ts
+++ b/src/commands/submit-challenge.ts
@@ -1,0 +1,102 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction } from 'discord.js';
+import { CustomCommand } from '../types/customCommand.js';
+import { getTournamentByName } from '../backend/queries/tournamentQueries.js';
+import { TournamentDocument } from '../types/customDocument.js';
+import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
+import { getChallengeOfTournamentByName } from '../backend/queries/challengeQueries.js';
+import { UserFacingError } from '../types/customError.js';
+import { getOrCreateContestant } from '../backend/queries/profileQueries.js';
+import { createSubmission, getSubmissionsForChallengeFromContestant } from '../backend/queries/submissionQueries.js';
+import { SubmissionStatus } from '../backend/schemas/submission.js';
+
+class ChallengeSubmissionError extends UserFacingError {
+    constructor(message: string, userMessage: string) {
+        super(message, userMessage);
+        this.name = 'ChallengeSubmissionError';
+    }
+}
+
+const submitChallenge = async (interaction: CommandInteraction): Promise<void> => {
+    // Use the specified tournament if provided. Otherwise attempt to use the current tournament, failing if there is none.
+    const tournamentName = interaction.options.get('tournament', false)?.value as string ?? '';
+    let tournament: TournamentDocument | null;
+    if (tournamentName) {
+        // A tournament was specified -- use it
+        tournament = await getTournamentByName(interaction.guildId!, tournamentName);
+        if (!tournament) throw new ChallengeSubmissionError(`Tournament ${tournamentName} not found in guild ${interaction.guildId}.`, `Your submission was not sent. That tournament, **${tournamentName}**, was not found.`);
+    } else {
+        // No tournament was specified...
+        const currentTournament = await getCurrentTournament(interaction.guildId!);
+        if (currentTournament) {
+            // ... and there is a current tournament -- use it...
+            tournament = currentTournament;
+            // ...unless it is hidden!
+            if (!tournament.visibility) throw new ChallengeSubmissionError(`Tournament ${tournament.name} is hidden.`, `Your submission was not sent. The current tournament is currently hidden and is not accepting submissions.`);
+        } else {
+            // ... and there is no current tournament -- fail
+            throw new ChallengeSubmissionError(`Guild ${interaction.guildId} has no current tournament.`, 'Your submission was not sent. There is no current tournament.');
+        }
+    }
+    const challengeName = interaction.options.get('name', true).value as string;
+    const challenge = await getChallengeOfTournamentByName(challengeName, tournament);
+    if (!challenge) throw new ChallengeSubmissionError(`Challenge ${challengeName} not found in tournament ${tournament.name}.`, `Your submission was not sent. That challenge, **${challengeName}**, was not found in the tournament **${tournament.name}**.`);
+
+    // Fail if the tournament or challenge is not active
+    if (!tournament.active) throw new ChallengeSubmissionError(`Tournament ${tournament.name} is not active.`, `Your submission was not sent. That tournament, **${tournament.name}**, is not accepting submissions.`);
+    if (!challenge.visibility) {
+        throw new ChallengeSubmissionError(`Challenge ${challenge.name} is not active.`, `Your submission was not sent. That challenge is currently hidden and is not accepting submissions.`);
+    }
+
+    // Check contestant status -- for now, just getOrCreate them... TODO
+    const contestant = await getOrCreateContestant(interaction.guildId!, interaction.user.id);
+
+    // Fail if no proof was provided
+    const proofLink = interaction.options.get('proof-link', true).value as string;
+    if (!proofLink) {
+        throw new ChallengeSubmissionError(`No proof was provided.`, `Your submission was not sent. You must provide one form proof of your completion of the challenge.`);
+    }
+
+    // Fail if contestant already has pending or accepted submission for this challenge
+    const submissions = await getSubmissionsForChallengeFromContestant(challenge, contestant);
+    if (submissions && submissions.filter(submission => submission.get('status') !== SubmissionStatus.Rejected).length > 0) {
+        throw new ChallengeSubmissionError(`Submission rejected due to pending or already accepted submission from this member.`, `Your submission was not sent. Your previous submission to this challenge is either waiting to be approved or was already approved.`);
+    }
+
+    try {
+        await createSubmission(challenge, contestant, proofLink);
+    } catch (err) {
+        if (err instanceof UserFacingError) {
+            throw new ChallengeSubmissionError(`Error in submit-challenge.ts: ${err.message}`, err.userMessage);
+        }
+        throw err;
+    }
+};
+
+const SubmitChallengeCommand = new CustomCommand(
+    new SlashCommandBuilder()
+        .setName('submit-challenge')
+        .setDescription('Send your submission for a challenge you completed, along with proof.')
+        .addStringOption(option => option.setName('name').setDescription('The name of the challenge.').setRequired(true))
+        .addStringOption(option => option.setName('proof-link').setDescription('Your proof of completing the challenge. Linkless? Send it on this server then Copy Message Link!').setRequired(true))
+        .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is part of. Defaults to current tournament.').setRequired(false)) as SlashCommandBuilder,
+    async (interaction: CommandInteraction) => {
+        // TODO: Privileges check
+
+
+        try {
+            await submitChallenge(interaction);
+            interaction.reply({ content: `✅ Submission sent for review!`, ephemeral: true });
+        } catch (err) {
+            if (err instanceof UserFacingError) {
+                interaction.reply({ content: `❌ ${err.userMessage}`, ephemeral: true });
+                return;
+            }
+            console.error(`Error in submit-challenge.ts: ${err}`);
+            interaction.reply({ content: `❌ There was an error while sending your submission!`, ephemeral: true });
+            return;
+        }
+    }
+);
+
+export default SubmitChallengeCommand;


### PR DESCRIPTION
Closes #22 

This is our first command meant to be used by the Contestants rather than the Judges. True to the nature of seeing things from the perspective, this actually provoked some thought regarding future work on the Contestant registration systems we want to allow, which I wrote about in #43. For now, this method uses the most lenient Contestant policy and future updates will be needed to change this behavior once those systems are in place.

This command also hits endpoints for almost all of the major models. With so many distinct ways for the command to fail, I decided to send and await these requests as-needed rather than sending them all out at the start and awaiting when finally needed. This method would be a good candidate to evaluate the performance implications of.

I've also started leaning towards making more complex Mongoose queries rather than performing logic like `filter` in the backend, e.g. `getChallengeOfTournamentByName`. Unsurprisingly, Mongoose allows pretty advanced techniques, and with the query builder syntax (which I've just learned about) it's way easier than the weird JSON syntax I was used to.

I'll also briefly draw attention to #28 and #42. For now on I will be favoring the practices described respectively to reduce refactoring work later down the line. This does present a style inconsistency with the rest of the codebase for now.

In general, nothing too fancy going on and code looks very reminiscent to previous commands. 