### PR TITLE
Add /judge-submission, /assign-judge commands with new architecture POC. Add Guilds intent

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
         "indent": ["error", 4, { "SwitchCase": 1 }],
         "no-empty-function": "warn",
         "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_" }],
+        "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
         "quotes": ["error", "single", { "allowTemplateLiterals": true }],
         "semi": ["error", "always"],
         "space-before-function-paren": ["error", {

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run ESLint
         run: npx eslint .
-          --config ../../.eslintrc.json
+          --config .eslintrc.json
           --ext .js,.jsx,.ts,.tsx
           --format @microsoft/eslint-formatter-sarif
           --output-file eslint-results.sarif

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run ESLint
         run: npx eslint .
-          --config .eslintrc.json
+          --config ../../.eslintrc.json
           --ext .js,.jsx,.ts,.tsx
           --format @microsoft/eslint-formatter-sarif
           --output-file eslint-results.sarif

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           npm install eslint@8.10.0
           npm install @microsoft/eslint-formatter-sarif@2.1.7
+          npm install @typescript-eslint/parser@6.0.0 @typescript-eslint/eslint-plugin@6.0.0 typescript@5.1.6
 
       - name: Run ESLint
         run: npx eslint .

--- a/src/backend/queries/challengeQueries.ts
+++ b/src/backend/queries/challengeQueries.ts
@@ -1,11 +1,12 @@
 import { ObjectId } from 'mongodb';
 import { ChallengeDocument, TournamentDocument } from '../../types/customDocument.js';
-import { ChallengeModel } from '../schemas/challenge.js';
+import { Challenge, ChallengeModel } from '../schemas/challenge.js';
 import { UpdateChallengeParams } from '../../types/apiPayloadObjects.js';
+import { Ref } from '@typegoose/typegoose';
 // CREATE / POST
 
 // READ / GET
-export const getChallengeById = async (id: ObjectId): Promise<ChallengeDocument | null> => {
+export const getChallengeById = async (id: Ref<Challenge> | string): Promise<ChallengeDocument | null> => {
     return ChallengeModel.findById(id);
 };
 

--- a/src/backend/queries/profileQueries.ts
+++ b/src/backend/queries/profileQueries.ts
@@ -48,6 +48,10 @@ export const getJudgeById = async (id: Ref<Judge> | string): Promise<JudgeDocume
     return JudgeModel.findById(id);
 };
 
+export const getJudgeByGuildIdAndMemberId = async (guildId: string, memberId: string): Promise<JudgeDocument | null> => {
+    return JudgeModel.findOne({ guildID: guildId, userID: memberId }).exec();
+};
+
 // UPDATE / PUT
 /**
  * Sets an existing Judge document to active or inactive. Does not upsert.

--- a/src/backend/queries/profileQueries.ts
+++ b/src/backend/queries/profileQueries.ts
@@ -1,7 +1,8 @@
 import { UpdateWriteOpResult } from 'mongoose';
 import { ContestantDocument, JudgeDocument } from '../../types/customDocument.js';
-import { ContestantModel } from '../schemas/contestant.js';
-import { JudgeModel } from '../schemas/judge.js';
+import { Contestant, ContestantModel } from '../schemas/contestant.js';
+import { Judge, JudgeModel } from '../schemas/judge.js';
+import { Ref } from '@typegoose/typegoose';
 
 // CREATE / POST
 export const createContestant = async (guildId: string, memberId: string): Promise<ContestantDocument> => {
@@ -33,6 +34,18 @@ export const getOrCreateContestant = async (guildId: string, memberId: string): 
     const contestant = await ContestantModel.findOne({ guildID: guildId, userID: memberId });
     if (contestant) return contestant;
     else return createContestant(guildId, memberId);
+};
+
+export const getContestantByGuildIdAndMemberId = async (guildId: string, memberId: string): Promise<ContestantDocument | null> => {
+    return ContestantModel.findOne({ guildID: guildId, userID: memberId });
+};
+
+export const getContestantById = async (id: Ref<Contestant> | string): Promise<ContestantDocument | null> => {
+    return ContestantModel.findById(id);
+};
+
+export const getJudgeById = async (id: Ref<Judge> | string): Promise<JudgeDocument | null> => {
+    return JudgeModel.findById(id);
 };
 
 // UPDATE / PUT

--- a/src/backend/queries/profileQueries.ts
+++ b/src/backend/queries/profileQueries.ts
@@ -61,7 +61,7 @@ export const getJudgeByGuildIdAndMemberId = async (guildId: string, memberId: st
  * @returns The result of the update operation.
  */
 export const setJudgeActive = async (guildId: string, memberId: string, active: boolean = true): Promise<UpdateWriteOpResult> => {
-    return JudgeModel.updateOne({ guildID: guildId, userID: memberId }).set({ isActiveJudge: active }).exec();
+    return JudgeModel.updateOne({ guildID: guildId, userID: memberId }, { $set: { isActiveJudge: active } }).exec();
 };
 
 /**

--- a/src/backend/queries/profileQueries.ts
+++ b/src/backend/queries/profileQueries.ts
@@ -1,11 +1,21 @@
-import { ContestantDocument } from '../../types/customDocument.js';
+import { UpdateWriteOpResult } from 'mongoose';
+import { ContestantDocument, JudgeDocument } from '../../types/customDocument.js';
 import { ContestantModel } from '../schemas/contestant.js';
+import { JudgeModel } from '../schemas/judge.js';
 
 // CREATE / POST
 export const createContestant = async (guildId: string, memberId: string): Promise<ContestantDocument> => {
     return ContestantModel.create({
         guildID: guildId,
         userID: memberId,
+    });
+};
+
+export const createJudge = async (guildId: string, memberId: string): Promise<JudgeDocument> => {
+    return JudgeModel.create({
+        guildID: guildId,
+        userID: memberId,
+        isActiveJudge: true,
     });
 };
 
@@ -26,5 +36,28 @@ export const getOrCreateContestant = async (guildId: string, memberId: string): 
 };
 
 // UPDATE / PUT
+/**
+ * Sets an existing Judge document to active or inactive. Does not upsert.
+ * @param guildId The Discord guild ID.
+ * @param memberId The Discord member ID.
+ * @param active If `false` or omitted, sets the Judge to inactive. Otherwise, sets the Judge to active.
+ * @returns The result of the update operation.
+ */
+export const setJudgeActive = async (guildId: string, memberId: string, active: boolean = true): Promise<UpdateWriteOpResult> => {
+    return JudgeModel.updateOne({ guildID: guildId, userID: memberId }).set({ isActiveJudge: active }).exec();
+};
+
+/**
+ * Sets a Judge as `active`, regardless of current status or existence, creating it if needed.
+ * In Mongoose terms, upserts the Judge as active.
+ * @param guildId The Discord guild ID.
+ * @param memberId The Discord member ID.
+ * @param active If `false`, sets the Judge to inactive (this is a very atypical use case).
+ * Otherwise, sets the Judge to active.
+ * @returns The result of the update operation.
+ */
+export const setOrCreateActiveJudge = async (guildId: string, memberId: string, active: boolean = true): Promise<UpdateWriteOpResult> => {
+    return JudgeModel.updateOne({ guildID: guildId, userID: memberId }, { $set: { isActiveJudge: active }}, { upsert: true }).exec();
+};
 
 // DELETE

--- a/src/backend/queries/submissionQueries.ts
+++ b/src/backend/queries/submissionQueries.ts
@@ -2,6 +2,7 @@ import { ReviewNote, ReviewNoteModel, Submission, SubmissionModel, SubmissionSta
 import { Ref } from '@typegoose/typegoose';
 import { Challenge } from '../schemas/challenge.js';
 import { Contestant } from '../schemas/contestant.js';
+import { Judge } from '../schemas/judge.js';
 
 // CREATE / POST
 export const createSubmission = async (challengeID: Ref<Challenge>, contestantID: Ref<Contestant>, proof: string) => {
@@ -11,6 +12,15 @@ export const createSubmission = async (challengeID: Ref<Challenge>, contestantID
         proof: proof,
         reviewNotes: [],
     });
+};
+
+export const createReviewNoteAndAddTo = async (submissionId: Ref<Submission> | string, judgeId: Ref<Judge> | string, status: SubmissionStatus, note?: string) => {
+    const reviewNote = await ReviewNoteModel.create({ 
+        judgeID: judgeId,
+        note: note ? note : '',
+        status: status,
+    });
+    return addReviewNoteToSubmission(submissionId, reviewNote);
 };
 
 // READ / GET
@@ -35,13 +45,12 @@ export const getNewestSubmissionForChallengeFromContestant = async (challengeId:
 };
 
 // UPDATE / PUT
-// TODO: Use refs instead of nested documents (#37)
-// export const addReviewNoteToSubmission = async (submission: Ref<Submission>, judgeID: Ref<Judge>, note: string, reviewStatus: SubmissionStatus) => {
-//     return SubmissionModel.findOneAndUpdate({ _id: submission}, {
-//         $push: {
-//             reviewNotes: new ReviewNoteModel({ judgeID: judgeID, note: note, status: reviewStatus }),
-//         }
-//     });
-// };
+export const addReviewNoteToSubmission = async (submissionId: Ref<Submission> | string, reviewNoteId: Ref<ReviewNote> | string) => {
+    return SubmissionModel.findOneAndUpdate({ _id: submissionId}, {
+        $push: {
+            reviewNotes: reviewNoteId,
+        }
+    }).exec();
+};
 
 // DELETE

--- a/src/backend/queries/submissionQueries.ts
+++ b/src/backend/queries/submissionQueries.ts
@@ -1,4 +1,4 @@
-import { Submission, SubmissionModel } from '../schemas/submission.js';
+import { ReviewNote, ReviewNoteModel, Submission, SubmissionModel, SubmissionStatus } from '../schemas/submission.js';
 import { Ref } from '@typegoose/typegoose';
 import { Challenge } from '../schemas/challenge.js';
 import { Contestant } from '../schemas/contestant.js';
@@ -15,19 +15,23 @@ export const createSubmission = async (challengeID: Ref<Challenge>, contestantID
 
 // READ / GET
 export const getSubmissionById = async (id: Ref<Submission> | string) => {
-    return SubmissionModel.findById(id);
+    return SubmissionModel.findById(id).exec();
 };
 
-export const getSubmissionsFromContestant = async (contestantID: Ref<Contestant>) => {
-    return SubmissionModel.find({ contestantID: contestantID });
+export const getSubmissionsFromContestant = async (contestantId: Ref<Contestant> | string) => {
+    return SubmissionModel.find({ contestantID: contestantId }).exec();
 };
 
-export const getSubmissionsForChallenge = async (challengeID: Ref<Challenge>) => {
-    return SubmissionModel.find({ challengeID: challengeID });
+export const getSubmissionsForChallenge = async (challengeId: Ref<Challenge> | string) => {
+    return SubmissionModel.find({ challengeID: challengeId }).exec();
 };
 
-export const getSubmissionsForChallengeFromContestant = async (challengeId: Ref<Challenge>, contestantId: Ref<Contestant>) => {
-    return SubmissionModel.find({ challengeID: challengeId, contestantID: contestantId });
+export const getSubmissionsForChallengeFromContestant = async (challengeId: Ref<Challenge> | string, contestantId: Ref<Contestant> | string) => {
+    return SubmissionModel.find({ challengeID: challengeId, contestantID: contestantId }).exec();
+};
+
+export const getNewestSubmissionForChallengeFromContestant = async (challengeId: Ref<Challenge> | string, contestantId: Ref<Contestant> | string) => {
+    return SubmissionModel.findOne({ challengeID: challengeId, contestantID: contestantId }).sort({ createdAt: -1 }).exec();
 };
 
 // UPDATE / PUT

--- a/src/backend/queries/submissionQueries.ts
+++ b/src/backend/queries/submissionQueries.ts
@@ -68,7 +68,9 @@ export const getSubmissionsForChallengeFromContestant = async (challengeId: Ref<
 };
 
 export const getNewestSubmissionForChallengeFromContestant = async (challengeId: Ref<Challenge> | string, contestantId: Ref<Contestant> | string) => {
-    return SubmissionModel.findOne({ challengeID: challengeId, contestantID: contestantId }).sort({ createdAt: -1 }).exec();
+    const newestSubmission = await SubmissionModel.find({ challengeID: challengeId, contestantID: contestantId }).sort({ createdAt: 'descending' }).limit(1).exec();
+    if (newestSubmission.length < 1) return null;
+    else return newestSubmission[0];
 };
 
 export const getReviewNoteById = async (id: Ref<ReviewNote> | string) => {

--- a/src/backend/queries/submissionQueries.ts
+++ b/src/backend/queries/submissionQueries.ts
@@ -3,6 +3,7 @@ import { Ref } from '@typegoose/typegoose';
 import { Challenge } from '../schemas/challenge.js';
 import { Contestant } from '../schemas/contestant.js';
 import { Judge } from '../schemas/judge.js';
+import { UpdateWriteOpResult } from 'mongoose';
 
 // CREATE / POST
 export const createSubmission = async (challengeID: Ref<Challenge>, contestantID: Ref<Contestant>, proof: string) => {
@@ -14,13 +15,38 @@ export const createSubmission = async (challengeID: Ref<Challenge>, contestantID
     });
 };
 
-export const createReviewNoteAndAddTo = async (submissionId: Ref<Submission> | string, judgeId: Ref<Judge> | string, status: SubmissionStatus, note?: string) => {
-    const reviewNote = await ReviewNoteModel.create({ 
-        judgeID: judgeId,
-        note: note ? note : '',
-        status: status,
-    });
-    return addReviewNoteToSubmission(submissionId, reviewNote);
+/**
+ * Upserts a ReviewNote, and adds it to the Submission's reviewNotes array if inserted. Note that
+ * this should only be used to upsert the newest ReviewNote.
+ * @param submissionId The Submission that will receive the ReviewNote update or the new ReviewNote.
+ * @param judgeId The Judge document ID of the Judge who submitted the review.
+ * @param status The new status of the ReviewNote.
+ * @param note The optional note the Judge submitted with the review.
+ * @returns The UpdateWriteOpResult, where the `matchedCount`, `modifiedCount`, and `upsertedCount`
+ * values correspond as noted, where only certain values are indicative of the result:
+ * - `1 0 ?`: An existing ReviewNote was not updated.
+ * - `1 1 ?`: An existing ReviewNote was updated.
+ * - `0 ? 1`: A new ReviewNote was created.
+ */
+export const createOrUpdateReviewNoteAndAddTo = async (submissionId: Ref<Submission> | string, judgeId: Ref<Judge> | string, status: SubmissionStatus, note?: string): Promise<UpdateWriteOpResult> => {
+    const submission = await getSubmissionById(submissionId);
+    if (!submission) throw new Error(`Error in submissionQueries.ts: Could not find submission ${submissionId}`);
+
+    // Appeal the previous review note, if it exists. Otherwise, add the new review note.
+    // First argument's complicated expression will become
+    // { id: idOfNewestReviewNote } or {}, inserting in the latter case
+    const reviewNoteUpdate = await ReviewNoteModel.updateOne({ ...(submission.reviewNotes.length > 0 && { _id: submission.reviewNotes[submission.reviewNotes.length - 1]._id }) }, {
+        $set: {
+            judgeID: judgeId,
+            status: status,
+            note: note ? note : '',
+        }
+    }, { upsert: true }).exec();
+
+    // If a new review note was created, add it to the submission
+    console.log(`DEBUG: ${reviewNoteUpdate.upsertedId!}`);
+    if (reviewNoteUpdate.matchedCount === 0) await addReviewNoteToSubmission(submissionId, reviewNoteUpdate.upsertedId!.toString());
+    return reviewNoteUpdate;
 };
 
 // READ / GET
@@ -44,9 +70,13 @@ export const getNewestSubmissionForChallengeFromContestant = async (challengeId:
     return SubmissionModel.findOne({ challengeID: challengeId, contestantID: contestantId }).sort({ createdAt: -1 }).exec();
 };
 
+export const getReviewNoteById = async (id: Ref<ReviewNote> | string) => {
+    return ReviewNoteModel.findById(id).exec();
+};
+
 // UPDATE / PUT
-export const addReviewNoteToSubmission = async (submissionId: Ref<Submission> | string, reviewNoteId: Ref<ReviewNote> | string) => {
-    return SubmissionModel.findOneAndUpdate({ _id: submissionId}, {
+export const addReviewNoteToSubmission = async (submissionId: Ref<Submission> | string, reviewNoteId: Ref<ReviewNote> | string): Promise<UpdateWriteOpResult> => {
+    return SubmissionModel.updateOne({ _id: submissionId}, {
         $push: {
             reviewNotes: reviewNoteId,
         }

--- a/src/backend/schemas/guildsettings.ts
+++ b/src/backend/schemas/guildsettings.ts
@@ -1,8 +1,11 @@
 import { prop, getModelForClass } from '@typegoose/typegoose';
 import { TournamentModel, Tournament } from './tournament.js';
 import { TournamentDocument } from '../../types/customDocument.js';
+import { ObjectId } from 'mongodb';
 
 export class GuildSettings {
+    _id!: ObjectId;
+
     @prop({ required: true, unique: true })
     public guildID!: string;
 

--- a/src/backend/schemas/judge.ts
+++ b/src/backend/schemas/judge.ts
@@ -1,7 +1,10 @@
 import { prop, index, getModelForClass } from '@typegoose/typegoose';
+import { ObjectId } from 'mongodb';
 
 @index({ userID: 1, guildID: 1 }, { unique: true })
 export class Judge {
+    _id!: ObjectId;
+
     @prop({ required: true, index: true})
     public userID!: string;
 

--- a/src/backend/schemas/submission.ts
+++ b/src/backend/schemas/submission.ts
@@ -41,19 +41,19 @@ export class Submission {
 
 export const ReviewNoteModel = getModelForClass(ReviewNote);
 
-export const SubmissionModel = getModelForClass(Submission);
+export const SubmissionModel = getModelForClass(Submission, { schemaOptions: { timestamps: true } });
 
 SubmissionModel.schema.virtual('resolvedReviewNotes').get(async function() {
     // If this doesn't work then try returning the promise and rename this resolvingReviewNotes
     // or try using the populate() method https://typegoose.github.io/typegoose/docs/api/virtuals/#virtual-populate
-    return await ReviewNoteModel.find({ _id: { $in: this.reviewNotes } }) as ReviewNote[];
+    return await ReviewNoteModel.find({ _id: { $in: this.reviewNotes } }).exec() as ReviewNote[];
 });
 
 SubmissionModel.schema.virtual('status').get(async function() {
     if (this.reviewNotes.length === 0) {
         return SubmissionStatus.PENDING;
     }
-    const resolvedReviewNotes: ReviewNote[] = this.get('resolvedReviewNotes');
+    const resolvedReviewNotes = await this.get('resolvedReviewNotes') as ReviewNote[];
     if (!resolvedReviewNotes) throw new Error(`Error in submission.ts: Could not get review notes for submission ${this._id}`);
     return resolvedReviewNotes.reduce(
         (prev: ReviewNote, curr: ReviewNote) => {

--- a/src/backend/schemas/submission.ts
+++ b/src/backend/schemas/submission.ts
@@ -5,10 +5,9 @@ import { Challenge } from './challenge.js';
 import { Contestant } from './contestant.js';
 
 export enum SubmissionStatus {
-    /* eslint-disable no-unused-vars */
-    Pending = 'Pending',
-    Accepted = 'Accepted',
-    Rejected = 'Rejected',
+    PENDING = 'PENDING',
+    ACCEPTED = 'ACCEPTED',
+    REJECTED = 'REJECTED',
 }
 
 export class ReviewNote {
@@ -52,7 +51,7 @@ SubmissionModel.schema.virtual('resolvedReviewNotes').get(async function() {
 
 SubmissionModel.schema.virtual('status').get(async function() {
     if (this.reviewNotes.length === 0) {
-        return SubmissionStatus.Pending;
+        return SubmissionStatus.PENDING;
     }
     const resolvedReviewNotes: ReviewNote[] = this.get('resolvedReviewNotes');
     if (!resolvedReviewNotes) throw new Error(`Error in submission.ts: Could not get review notes for submission ${this._id}`);

--- a/src/commands/assign-judge.ts
+++ b/src/commands/assign-judge.ts
@@ -130,7 +130,7 @@ const assignJudgeSlashCommandValidator = async (interaction: LimitedCommandInter
         targetId = who.user!.id;
         revoke = interaction.options.get('revoke', false)?.value as boolean;
 
-        validateConstraints(interaction, metadataConstraints, optionConstraints);
+        await validateConstraints(interaction, metadataConstraints, optionConstraints);
     } catch (err) {
         if (err instanceof OptionValidationError) return ({
             status: OutcomeStatus.FAIL_VALIDATION,

--- a/src/commands/assign-judge.ts
+++ b/src/commands/assign-judge.ts
@@ -1,0 +1,204 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction, CommandInteractionOption, User } from 'discord.js';
+import { CustomCommand } from '../types/customCommand.js';
+import { NonexistentJointGuildAndMemberError, OptionValidationError, OptionValidationErrorStatus, UnknownError, UserFacingError } from '../types/customError.js';
+import { setJudgeActive, setOrCreateActiveJudge } from '../backend/queries/profileQueries.js';
+import { LimitedCommandInteraction, limitCommandInteraction } from '../types/limitedCommandInteraction.js';
+import { OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeWithDuoBody, OutcomeWithDuoListBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
+import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
+import { ValueOf } from '../types/typelogic.js';
+import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
+
+/**
+ * Status codes specific to this command.
+ */
+enum AssignJudgeSpecificStatus {
+    SUCCESS_JUDGE_UPDATED = 'SUCCESS_JUDGE_UPDATED',
+    SUCCESS_JUDGE_CREATED = 'SUCCESS_JUDGE_CREATED',
+}
+
+/**
+ * Union of specific and generic status codes.
+ */
+type AssignJudgeStatus = AssignJudgeSpecificStatus | OutcomeStatus;
+
+/**
+ * The outcome format for the specific status code(s).
+ */
+type AssignJudgeSuccessJudgeUpdatedOutcome = {
+    status: AssignJudgeSpecificStatus.SUCCESS_JUDGE_UPDATED;
+    body: {
+        user: string;
+        active: boolean;
+    };
+}
+
+type AssignJudgeSuccessJudgeCreatedOutcome = {
+    status: AssignJudgeSpecificStatus.SUCCESS_JUDGE_CREATED;
+    body: {
+        user: string;
+    };
+};
+
+/**
+ * Union of specific and generic outcomes.
+ */
+type AssignJudgeOutcome = AssignJudgeSuccessJudgeUpdatedOutcome | AssignJudgeSuccessJudgeCreatedOutcome | Outcome<string | boolean, string | boolean>;
+
+/**
+ * 
+ * @param guildId The Discord guild ID.
+ * @param memberId The Discord member ID.
+ * @param revoke If `true`, sets the Judge to inactive. Otherwise, sets the Judge to active.
+ * @returns 
+ */
+const assignJudge = async (guildId: string, memberId: string, revoke?: boolean): Promise<AssignJudgeOutcome> => {
+    try {
+        const result = await (revoke ? setJudgeActive(guildId, memberId, false) : setOrCreateActiveJudge(guildId, memberId));
+        if (result.matchedCount === 1 && result.modifiedCount === 0) {
+            // The Judge already exists and is already in the desired state
+            return {
+                status: OutcomeStatus.SUCCESS_NO_CHANGE,
+                body: {
+                    data1: [memberId],
+                    data2: [!revoke],
+                }
+            };
+        } else if (result.matchedCount === 1 && result.modifiedCount === 1) {
+            // The Judge already exists and was modified to the desired state
+            return {
+                status: AssignJudgeSpecificStatus.SUCCESS_JUDGE_UPDATED,
+                body: {
+                    user: memberId,
+                    active: revoke ? false : true,
+                }
+            };
+        } else if (result.matchedCount === 0 && (result.upsertedCount === 1 || !revoke)) {
+            // The Judge did not exist and was created with an active status, or they (ineffectually) tried to unrevoke a nonexistent Judge
+            return {
+                status: AssignJudgeSpecificStatus.SUCCESS_JUDGE_CREATED,
+                body: {
+                    user: memberId,
+                }
+            };
+        } else if (result.matchedCount === 0) {
+            // The Judge did not exist and was not created -- i.e. they tried to revoke a nonexistent Judge
+            throw new NonexistentJointGuildAndMemberError(guildId, memberId);
+        } else throw new UnknownError(`Error in assign-judge.ts: Unexpected query result: ${result}.`);
+    } catch (err) {
+        if (err instanceof UserFacingError) {
+            // TODO
+        } else if (err instanceof NonexistentJointGuildAndMemberError) {
+            return {
+                status: OutcomeStatus.FAIL_DNE_DUO,
+                body: {
+                    data1: err.guildId,
+                    data2: err.memberId,
+                }
+            };
+        }
+    }
+
+    return {
+        status: OutcomeStatus.FAIL_UNKNOWN,
+        body: {},
+    };
+};
+
+const assignJudgeSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<AssignJudgeOutcome> => {
+    let guildId: string;
+    let targetId: string;
+    let revoke: boolean;
+
+    const who = interaction.options.get('who', true);
+
+    const metadataConstraints = new Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>([
+
+    ]);
+
+    const optionConstraints = new Map<CommandInteractionOption, [Constraint<ValueOf<CommandInteractionOption>>]>([
+        [who, [
+            // Ensure that the target is not a bot
+            {
+                category: OptionValidationErrorStatus.TARGET_USER_BOT,
+                func: function(option: ValueOf<CommandInteractionOption>): boolean {
+                    return !(option as User).bot;
+                },
+            },
+        ]],
+    ]);
+
+    try {
+        guildId = interaction.guildId!;
+        targetId = who.user!.id;
+        revoke = interaction.options.get('revoke', false)?.value as boolean;
+
+        validateConstraints(interaction, metadataConstraints, optionConstraints);
+    } catch (err) {
+        if (err instanceof OptionValidationError) {
+            return {
+                status: OutcomeStatus.FAIL_VALIDATION,
+                body: {
+                    constraint: err.constraint,
+                    field: err.field,
+                    value: err.value,
+                }
+            };
+        } else {
+            console.error(err);
+            throw err;
+        }
+    }
+
+    return await assignJudge(guildId, targetId, revoke);
+};
+
+const assignJudgeSlashCommandDescriptions = new Map<AssignJudgeStatus, (o: AssignJudgeOutcome) => SlashCommandDescribedOutcome>([
+    [AssignJudgeSpecificStatus.SUCCESS_JUDGE_UPDATED, (o: AssignJudgeOutcome) => ({
+        userMessage: `✅ <@${(o as AssignJudgeSuccessJudgeUpdatedOutcome).body.user}> is ${(o as AssignJudgeSuccessJudgeUpdatedOutcome).body.active ? 'now an active judge!' : 'no longer an active judge.'}`, ephemeral: true   
+    })],
+    [AssignJudgeSpecificStatus.SUCCESS_JUDGE_CREATED, (o: AssignJudgeOutcome) => ({
+        userMessage: `✅ <@${(o as AssignJudgeSuccessJudgeCreatedOutcome).body.user}> is now a new judge!`, ephemeral: true   
+    })],
+    [OutcomeStatus.SUCCESS_NO_CHANGE, (o: AssignJudgeOutcome) => ({
+        userMessage: `✅ <@${(o as OutcomeWithDuoListBody<string, boolean>).body.data1[0]}> is already ${(o as OutcomeWithDuoListBody<string, boolean>).body.data2[0] ? '' : 'not '}a judge.`, ephemeral: true   
+    })],
+    [OutcomeStatus.FAIL_DNE_DUO, (o: AssignJudgeOutcome) => ({
+        userMessage: `❌ <@${(o as OutcomeWithDuoBody<string>).body.data2}> is not a judge, so you cannot revoke them.`, ephemeral: true   
+    })],
+    [OutcomeStatus.FAIL_VALIDATION, (o: AssignJudgeOutcome) => ({
+        userMessage: `❌ ${(o as OptionValidationErrorOutcome<string>).body.value} is a bot, so you cannot use this command on them.`, ephemeral: true
+    })],
+]);
+
+const assignJudgeSlashCommandOutcomeDescriber = async (interaction: LimitedCommandInteraction): Promise<SlashCommandDescribedOutcome> => {
+    const outcome = await assignJudgeSlashCommandValidator(interaction);
+    if (assignJudgeSlashCommandDescriptions.has(outcome.status)) {
+        return assignJudgeSlashCommandDescriptions.get(outcome.status)!(outcome);
+    } 
+    // Fallback to trying default descriptions
+    const defaultOutcome = outcome as Outcome<string>;
+    if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
+        return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
+    } else {
+        return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
+    }
+};
+
+const assignJudgeCommandReplyer = async (interaction: CommandInteraction): Promise<void> => {
+    const describedOutcome = await assignJudgeSlashCommandOutcomeDescriber(limitCommandInteraction(interaction));
+    interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
+};
+
+const AssignJudgeSlashCommand = new CustomCommand(
+    new SlashCommandBuilder()
+        .setName('assign-judge')
+        .setDescription('Assign someone as a judge for challenge submissions in all tournaments, or revoke judge permissions.')
+        .addUserOption(option => option.setName('who').setDescription('The new judge to assign, or whose permissions to modify.').setRequired(true))
+        .addBooleanOption(option => option.setName('revoke').setDescription('To revoke an existing judge, use True. To re-assign a judge, use False or leave this blank.').setRequired(false)) as SlashCommandBuilder,
+    async (interaction: CommandInteraction) => {
+        await assignJudgeCommandReplyer(interaction);
+    }
+);
+
+export default AssignJudgeSlashCommand;

--- a/src/commands/assign-judge.ts
+++ b/src/commands/assign-judge.ts
@@ -60,7 +60,9 @@ const assignJudge = async (guildId: string, memberId: string, revoke?: boolean):
             status: OutcomeStatus.SUCCESS_NO_CHANGE,
             body: {
                 data1: [memberId],
+                context1: 'memberId',
                 data2: [!revoke],
+                context2: 'isActiveJudge',
             },
         });
         if (result.matchedCount === 1 && result.modifiedCount === 1) return ({
@@ -87,7 +89,9 @@ const assignJudge = async (guildId: string, memberId: string, revoke?: boolean):
             status: OutcomeStatus.FAIL_DNE_DUO,
             body: {
                 data1: err.guildId,
+                context1: 'guildId',
                 data2: err.memberId,
+                context2: 'memberId',
             }
         });
     }
@@ -134,6 +138,7 @@ const assignJudgeSlashCommandValidator = async (interaction: LimitedCommandInter
                 constraint: err.constraint,
                 field: err.field,
                 value: err.value,
+                context: err.message,
             },
         });
 

--- a/src/commands/assign-judge.ts
+++ b/src/commands/assign-judge.ts
@@ -4,7 +4,7 @@ import { CustomCommand } from '../types/customCommand.js';
 import { NonexistentJointGuildAndMemberError, OptionValidationError, OptionValidationErrorStatus, UnknownError } from '../types/customError.js';
 import { setJudgeActive, setOrCreateActiveJudge } from '../backend/queries/profileQueries.js';
 import { LimitedCommandInteraction, limitCommandInteraction } from '../types/limitedCommandInteraction.js';
-import { OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeWithDuoBody, OutcomeWithDuoListBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
+import { Outcome, OutcomeStatus, OutcomeWithDuoBody, OutcomeWithDuoListBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
 import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
 import { ValueOf } from '../types/typelogic.js';
 import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
@@ -160,9 +160,6 @@ const assignJudgeSlashCommandDescriptions = new Map<AssignJudgeStatus, (o: Assig
     })],
     [OutcomeStatus.FAIL_DNE_DUO, (o: AssignJudgeOutcome) => ({
         userMessage: `❌ <@${(o as OutcomeWithDuoBody<string>).body.data2}> is not a judge, so you cannot revoke them.`, ephemeral: true   
-    })],
-    [OutcomeStatus.FAIL_VALIDATION, (o: AssignJudgeOutcome) => ({
-        userMessage: `❌ ${(o as OptionValidationErrorOutcome<string>).body.value} is a bot, so you cannot use this command on them.`, ephemeral: true
     })],
 ]);
 

--- a/src/commands/assign-judge.ts
+++ b/src/commands/assign-judge.ts
@@ -112,8 +112,10 @@ const assignJudgeSlashCommandValidator = async (interaction: LimitedCommandInter
             // Ensure that the target is not a bot
             {
                 category: OptionValidationErrorStatus.TARGET_USER_BOT,
-                func: function(option: ValueOf<CommandInteractionOption>): boolean {
-                    return !(option as User).bot;
+                func: async function(option: ValueOf<CommandInteractionOption>): Promise<boolean> {
+                    return new Promise(function(resolve) {
+                        resolve(!(option as User).bot);
+                    });
                 },
             },
         ]],

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
-import { CommandInteraction, CommandInteractionOption, GuildMember } from 'discord.js';
+import { CommandInteraction, CommandInteractionOption, GuildMember, PermissionsBitField } from 'discord.js';
 import { CustomCommand } from '../types/customCommand.js';
 import { OutcomeStatus, Outcome, SlashCommandDescribedOutcome, OutcomeWithDuoListBody, OutcomeWithDuoBody, OutcomeWithMonoBody, OptionValidationErrorOutcome } from '../types/outcome.js';
 import { getChallengeOfTournamentByName } from '../backend/queries/challengeQueries.js';
@@ -56,9 +56,10 @@ type JudgeSubmissionOutcome = AssignJudgeSuccessSubmissionReviewedOutcome | Assi
 
 /**
  * Judges the newest submission for a challenge from a contestant.
- * @param challengeId The ID of the Challenge document to judge.
- * @param contestantId The ID of the Contestant document, which is NOT the Discord member ID.
- * @param judgeId The ID of the Judge document, which is NOT the Discord member ID.
+ * @param guildId The Discord guild ID.
+ * @param challengeName The name of the challenge the submission is for.
+ * @param contestantId The Discord member ID of the contestant.
+ * @param judgeId The Discord member ID of the judge.
  * @param approve Whether to approve the submission (true) or reject it (false).
  * @param notes Optional notes to leave on the submission.
  * @param tournamentName The name of the Tournament the Challenge is part of. If provided, it should exist; otherwise, defaults to the current Tournament.
@@ -109,19 +110,6 @@ const judgeSubmission = async (guildId: string, challengeName: string, contestan
             body: {
                 data: judgeId,
                 context: 'judge',
-            },
-        });
-        if (!judge.isActiveJudge) return ({
-            // This might be later considered a misuse of FAIL_VALIDATION and need to be refactored (sort of related to #50)...
-            status: OutcomeStatus.FAIL_VALIDATION,
-            body: {
-                constraint: {
-                    category: OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS,
-                    func: (_: string) => new Promise((resolve) => resolve(false)),
-                },
-                field: 'memberId',
-                value: judgeId,
-                context: 'active judge',
             },
         });
 

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -1,0 +1,44 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction } from 'discord.js';
+import { CustomCommand } from '../types/customCommand.js';
+import { UserFacingError } from '../types/customError.js';
+
+class JudgeSubmissionError extends UserFacingError {
+    constructor(message: string, userMessage: string) {
+        super(message, userMessage);
+        this.name = 'JudgeSubmissionError';
+    }
+}
+
+const judgeSubmission = async (interaction: CommandInteraction): Promise<void> => {
+    
+};
+
+const JudgeSubmissionCommand = new CustomCommand(
+    new SlashCommandBuilder()
+        .setName('judge-submission')
+        .setDescription('Approve or reject the submission for a challenge from a contestant.')
+        .addStringOption(option => option.setName('name').setDescription('The name of the challenge.').setRequired(true))
+        .addUserOption(option => option.setName('contestant').setDescription('The contestant who submitted the challenge.').setRequired(true))
+        .addBooleanOption(option => option.setName('approve').setDescription('Approve the submission with True, reject it with False.').setRequired(true))
+        .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is part of. Defaults to current tournament.').setRequired(false)) as SlashCommandBuilder,
+    async (interaction: CommandInteraction) => {
+        // TODO: Privileges check
+
+
+        try {
+            await judgeSubmission(interaction);
+            interaction.reply({ content: `✅ Submission judged!`, ephemeral: true });
+        } catch (err) {
+            if (err instanceof UserFacingError) {
+                interaction.reply({ content: `❌ ${err.userMessage}`, ephemeral: true });
+                return;
+            }
+            console.error(`Error in judge-submission.ts: ${err}`);
+            interaction.reply({ content: `❌ There was an error while judging the submission!`, ephemeral: true });
+            return;
+        }
+    }
+);
+
+export default JudgeSubmissionCommand;

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -164,8 +164,7 @@ const judgeSubmissionSlashCommandValidator = async (interaction: LimitedCommandI
                 category: OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS,
                 func: async function(metadata: ValueOf<LimitedCommandInteraction>): Promise<boolean> {
                     const judge = await getJudgeByGuildIdAndMemberId(guildId, (metadata as GuildMember).id);
-                    if (!judge) return false;
-                    return judge.isActiveJudge || (metadata as GuildMember).permissions.has(PermissionsBitField.Flags.Administrator);
+                    return (judge && judge.isActiveJudge) || (metadata as GuildMember).permissions.has(PermissionsBitField.Flags.Administrator);
                 },
             },
         ]],
@@ -252,7 +251,7 @@ const judgeSubmissionSlashCommandDescriptions = new Map<JudgeSubmissionStatus, (
             userMessage: `❌ This failed because <@${oBody.data}> might not be a contestant.`, ephemeral: true
         });
         else if (oBody.context === 'judge') return ({
-            userMessage: `❌ <@${oBody.data}>, you are not a judge.`, ephemeral: true
+            userMessage: `❌ You haven't been fully set up as a judge yet. Please have a server admin use \`/assign-judge \`<@${oBody.data}>.`, ephemeral: true
         });
         else if (oBody.context === 'challenge') return ({
             userMessage: `❌ The challenge **${oBody.data}** was not found.`, ephemeral: true

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -208,7 +208,7 @@ const judgeSubmissionSlashCommandValidator = async (interaction: LimitedCommandI
         const notesOption = interaction.options.get('notes', false);
         notes = (notesOption && typeof notesOption.value === 'string' ? notesOption.value : '');
 
-        validateConstraints(interaction, metadataConstraints, optionConstraints);
+        await validateConstraints(interaction, metadataConstraints, optionConstraints);
     } catch (err) {
         if (err instanceof OptionValidationError) return ({
             status: OutcomeStatus.FAIL_VALIDATION,

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -1,18 +1,6 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction } from 'discord.js';
 import { CustomCommand } from '../types/customCommand.js';
-import { UserFacingError } from '../types/customError.js';
-
-class JudgeSubmissionError extends UserFacingError {
-    constructor(message: string, userMessage: string) {
-        super(message, userMessage);
-        this.name = 'JudgeSubmissionError';
-    }
-}
-
-const judgeSubmission = async (interaction: CommandInteraction): Promise<void> => {
-    
-};
 
 const JudgeSubmissionCommand = new CustomCommand(
     new SlashCommandBuilder()
@@ -23,21 +11,7 @@ const JudgeSubmissionCommand = new CustomCommand(
         .addBooleanOption(option => option.setName('approve').setDescription('Approve the submission with True, reject it with False.').setRequired(true))
         .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is part of. Defaults to current tournament.').setRequired(false)) as SlashCommandBuilder,
     async (interaction: CommandInteraction) => {
-        // TODO: Privileges check
-
-
-        try {
-            await judgeSubmission(interaction);
-            interaction.reply({ content: `✅ Submission judged!`, ephemeral: true });
-        } catch (err) {
-            if (err instanceof UserFacingError) {
-                interaction.reply({ content: `❌ ${err.userMessage}`, ephemeral: true });
-                return;
-            }
-            console.error(`Error in judge-submission.ts: ${err}`);
-            interaction.reply({ content: `❌ There was an error while judging the submission!`, ephemeral: true });
-            return;
-        }
+        interaction.reply({ content: 'This command is not yet implemented.', ephemeral: true });
     }
 );
 

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -171,13 +171,13 @@ const judgeSubmissionSlashCommandValidator = async (interaction: LimitedCommandI
 
     const metadataConstraints = new Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>([
         ['member', [
-            // Ensure that the sender is a Judge
+            // Ensure that the sender is a Judge or Administrator
             {
                 category: OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS,
                 func: async function(metadata: ValueOf<LimitedCommandInteraction>): Promise<boolean> {
-                    const judge = await getJudgeByGuildIdAndMemberId(guildId, (metadata as GuildMember)!.id!);
+                    const judge = await getJudgeByGuildIdAndMemberId(guildId, (metadata as GuildMember).id);
                     if (!judge) return false;
-                    return judge.isActiveJudge || (metadata as GuildMember).permissions.has('Administrator');
+                    return judge.isActiveJudge || (metadata as GuildMember).permissions.has(PermissionsBitField.Flags.Administrator);
                 },
             },
         ]],

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -277,7 +277,7 @@ const judgeSubmissionSlashCommandDescriptions = new Map<JudgeSubmissionStatus, (
             userMessage: `❌ The tournament **${oBody.value}** was not found.`, ephemeral: true
         });
         else return ({
-            userMessage: `❌ This command failed unexpectedly.`, ephemeral: true
+            userMessage: `❌ This command failed unexpectedly due to a validation error.`, ephemeral: true
         });
     }],
 ]);

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -1,17 +1,325 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
-import { CommandInteraction } from 'discord.js';
+import { CommandInteraction, CommandInteractionOption, GuildMember } from 'discord.js';
 import { CustomCommand } from '../types/customCommand.js';
+import { OutcomeStatus, Outcome, SlashCommandDescribedOutcome, OutcomeWithDuoListBody, OutcomeWithDuoBody, OutcomeWithMonoBody, OptionValidationErrorOutcome } from '../types/outcome.js';
+import { getChallengeOfTournamentByName } from '../backend/queries/challengeQueries.js';
+import { getContestantByGuildIdAndMemberId, getJudgeByGuildIdAndMemberId } from '../backend/queries/profileQueries.js';
+import { createOrUpdateReviewNoteAndAddTo, getNewestSubmissionForChallengeFromContestant } from '../backend/queries/submissionQueries.js';
+import { OptionValidationError, OptionValidationErrorStatus } from '../types/customError.js';
+import { SubmissionStatus } from '../backend/schemas/submission.js';
+import { LimitedCommandInteraction, limitCommandInteraction } from '../types/limitedCommandInteraction.js';
+import { ValueOf } from '../types/typelogic.js';
+import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
+import { getTournamentByName } from '../backend/queries/tournamentQueries.js';
+import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
+import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
+
+/**
+ * Status codes specific to this command.
+ */
+enum JudgeSubmissionSpecificStatus {
+    SUCCESS_SUBMISSION_REVIEWED = 'SUCCESS_SUBMISSION_REVIEWED',
+    SUCCESS_SUBMISSION_APPEALED = 'SUCCESS_SUBMISSION_APPEALED',
+}
+
+/**
+ * Union of specific and generic status codes.
+ */
+type JudgeSubmissionStatus = JudgeSubmissionSpecificStatus | OutcomeStatus;
+
+/**
+ * The outcome format for the specific status code(s).
+ */
+type AssignJudgeSuccessSubmissionReviewedOutcome = {
+    status: JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_REVIEWED;
+    body: {
+        user: string;
+        challengeName: string;
+        approved: boolean;
+    };
+}
+
+type AssignJudgeSuccessSubmissionAppealedOutcome = {
+    status: JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_APPEALED;
+    body: {
+        user: string;
+        challengeName: string;
+        previousApproved: boolean;
+        approved: boolean;
+    };
+};
+
+/**
+ * Union of specific and generic outcomes.
+ */
+type JudgeSubmissionOutcome = AssignJudgeSuccessSubmissionReviewedOutcome | AssignJudgeSuccessSubmissionAppealedOutcome | Outcome<string, boolean>;
+
+/**
+ * Judges the newest submission for a challenge from a contestant.
+ * @param challengeId The ID of the Challenge document to judge.
+ * @param contestantId The ID of the Contestant document, which is NOT the Discord member ID.
+ * @param judgeId The ID of the Judge document, which is NOT the Discord member ID.
+ * @param approve Whether to approve the submission (true) or reject it (false).
+ * @param notes Optional notes to leave on the submission.
+ * @param tournamentName The name of the Tournament the Challenge is part of. If provided, it should exist; otherwise, defaults to the current Tournament.
+ * @returns 
+ */
+const judgeSubmission = async (guildId: string, challengeName: string, contestantId: string, judgeId: string, approve: boolean, notes?: string, tournamentName?: string): Promise<JudgeSubmissionOutcome> => {
+    try {
+        // Ensure the Tournament, Challenge, Contestant, active Judge, and newest Submission exist
+        const tournament = tournamentName ? await getTournamentByName(guildId, tournamentName) : await getCurrentTournament(guildId);
+        if (!tournament) return ({
+            status: OutcomeStatus.FAIL_DNE_MONO,
+            body: {
+                data: tournamentName ? tournamentName : '(currentTournament)',
+                context: 'tournament',
+            },
+        });
+        const challenge = await getChallengeOfTournamentByName(challengeName, tournament);
+        if (!challenge) return ({
+            status: OutcomeStatus.FAIL_DNE_DUO,
+            body: {
+                data1: challengeName,
+                context1: 'challenge',
+                data2: tournament.name,
+                context2: 'tournament',
+            },
+        });
+        const contestant = await getContestantByGuildIdAndMemberId(guildId, contestantId);
+        if (!contestant) return ({
+            status: OutcomeStatus.FAIL_DNE_MONO,
+            body: {
+                data: contestantId,
+                context: 'user',
+            },
+        });
+        const submission = await getNewestSubmissionForChallengeFromContestant(challenge, contestant);
+        if (!submission) return ({
+            status: OutcomeStatus.FAIL_DNE_DUO,
+            body: {
+                data1: challenge.name,
+                context1: 'challenge',
+                data2: contestantId,
+                context2: 'user',
+            },
+        });
+        const judge = await getJudgeByGuildIdAndMemberId(guildId, judgeId);
+        if (!judge) return ({
+            status: OutcomeStatus.FAIL_DNE_MONO,
+            body: {
+                data: judgeId,
+                context: 'judge',
+            },
+        });
+        if (!judge.isActiveJudge) return ({
+            // This might be later considered a misuse of FAIL_VALIDATION and need to be refactored (sort of related to #50)...
+            status: OutcomeStatus.FAIL_VALIDATION,
+            body: {
+                constraint: {
+                    category: OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS,
+                    func: (_: string) => new Promise((resolve) => resolve(false)),
+                },
+                field: 'memberId',
+                value: judgeId,
+                context: 'active judge',
+            },
+        });
+
+        // Create a ReviewNote for the submission
+        const result = (await createOrUpdateReviewNoteAndAddTo(submission, judge, approve ? SubmissionStatus.ACCEPTED : SubmissionStatus.REJECTED, notes))!;
+        if (result.matchedCount === 1 && result.modifiedCount === 0) return ({
+            // The submission was reviewed before and is already in the desired status
+            status: OutcomeStatus.SUCCESS_NO_CHANGE,
+            body: {
+                data1: [contestantId, challengeName],
+                context1: 'user, challenge',
+                data2: [approve],
+                context2: 'approved',
+            },
+        });
+        if (result.matchedCount === 1 && result.modifiedCount === 1) return ({
+            // The submission was reviewed before and was modified to the desired status
+            status: JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_APPEALED,
+            body: {
+                user: contestant.userID,
+                challengeName: challengeName,
+                previousApproved: !approve,
+                approved: approve,
+            },
+        });
+        if (result.matchedCount === 0 && result.upsertedCount === 1) return ({
+            // The submission was not reviewed before and was created with the desired status
+            status: JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_REVIEWED,
+            body: {
+                user: contestant.userID,
+                challengeName: challengeName,
+                approved: approve,
+            },
+        });
+    } catch (err) {
+        // No expected thrown errors
+    }
+
+    return ({
+        status: OutcomeStatus.FAIL_UNKNOWN,
+        body: {},
+    });
+};
+
+const judgeSubmissionSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<JudgeSubmissionOutcome> => {
+    const guildId = interaction.guildId!;
+
+    const metadataConstraints = new Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>([
+        ['member', [
+            // Ensure that the sender is a Judge
+            {
+                category: OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS,
+                func: async function(metadata: ValueOf<LimitedCommandInteraction>): Promise<boolean> {
+                    const judge = await getJudgeByGuildIdAndMemberId(guildId, (metadata as GuildMember)!.id!);
+                    if (!judge) return false;
+                    return judge.isActiveJudge || (metadata as GuildMember).permissions.has('Administrator');
+                },
+            },
+        ]],
+    ]);
+
+    const contestant = interaction.options.get('contestant', true);
+    const tournament = interaction.options.get('tournament', false);
+
+    const optionConstraints = new Map<CommandInteractionOption | null, [Constraint<ValueOf<CommandInteractionOption>>]>([
+        [tournament, [
+            // Ensure that the tournament exists, if it was provided
+            {
+                category: OptionValidationErrorStatus.OPTION_DNE,
+                func: async function(option: ValueOf<CommandInteractionOption>): Promise<boolean> {
+                    const tournamentDocument = await getTournamentByName(guildId, option as string);
+                    return tournamentDocument !== null;
+                }
+            },
+        ]],
+    ]);
+
+    let challengeName: string;
+    let approve: boolean;
+    let notes: string;
+    try {
+        challengeName = interaction.options.get('name', true).value! as string;
+        approve = interaction.options.get('approve', true).value! as boolean;
+        const notesOption = interaction.options.get('notes', false);
+        notes = (notesOption && typeof notesOption.value === 'string' ? notesOption.value : '');
+
+        validateConstraints(interaction, metadataConstraints, optionConstraints);
+    } catch (err) {
+        if (err instanceof OptionValidationError) return ({
+            status: OutcomeStatus.FAIL_VALIDATION,
+            body: {
+                constraint: err.constraint,
+                field: err.field,
+                value: err.value,
+                context: err.message,
+            },
+        });
+
+        throw err;
+    }
+
+    return await judgeSubmission(guildId, challengeName, contestant.user!.id, interaction.member!.user!.id, approve, notes, (tournament ? tournament.value as string : undefined));
+};
+
+const judgeSubmissionSlashCommandDescriptions = new Map<JudgeSubmissionStatus, (o: JudgeSubmissionOutcome) => SlashCommandDescribedOutcome>([
+    [JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_REVIEWED, (o: JudgeSubmissionOutcome) => {
+        const oBody = (o as AssignJudgeSuccessSubmissionReviewedOutcome).body; 
+        return {
+            userMessage: `✅ <@${oBody.user}>'s submission for **${oBody.challengeName}** ${oBody.approved ? 'approved' : 'rejected'}!`, ephemeral: true
+        };
+    }],
+    [JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_APPEALED, (o: JudgeSubmissionOutcome) => {
+        const oBody = (o as AssignJudgeSuccessSubmissionAppealedOutcome).body;
+        return {
+            userMessage: `✅ <@${oBody.user}>'s previously ${oBody.previousApproved ? 'approved' : 'rejected'} submission for **${oBody.challengeName}** has been ${oBody.approved ? 'approved' : 'rejected'}!`, ephemeral: true
+        };
+    }],
+    [OutcomeStatus.SUCCESS_NO_CHANGE, (o: JudgeSubmissionOutcome) => {
+        const oBody = (o as OutcomeWithDuoListBody<string, boolean>).body;
+        return {
+            userMessage: `✅ <@${oBody.data1[0]}>'s submission for ${oBody.data1[1]} was already ${oBody.data2[0] ? 'approved' : 'rejected'}.`, ephemeral: true
+        };
+    }],
+    [OutcomeStatus.FAIL_DNE_DUO, (o: JudgeSubmissionOutcome) => {
+        const oBody = (o as OutcomeWithDuoBody<string>).body;
+        if (oBody.context1 === 'challenge' && oBody.context2 === 'tournament') return ({
+            userMessage: `❌ The challenge **${oBody.data1}** was not found in the tournament **${oBody.data2}**.`, ephemeral: true
+        });
+        else if (oBody.context1 === 'challenge' && oBody.context2 === 'user') return ({
+            userMessage: `❌ <@${oBody.data2}> has not submitted a challenge for ${(o as OutcomeWithDuoBody<string>).body.data1}.`, ephemeral: true
+        });
+        else return ({
+            userMessage: `❌ This command failed unexpectedly.`, ephemeral: true
+        });
+    }],
+    [OutcomeStatus.FAIL_DNE_MONO, (o: JudgeSubmissionOutcome) => {
+        const oBody = (o as OutcomeWithMonoBody<string>).body;
+        // Use context to describe what entity doesn't exist.
+        if (oBody.context === 'user') return ({
+            userMessage: `❌ This failed because <@${oBody.data}> might not be a contestant.`, ephemeral: true
+        });
+        else if (oBody.context === 'judge') return ({
+            userMessage: `❌ <@${oBody.data}>, you are not a judge.`, ephemeral: true
+        });
+        else if (oBody.context === 'challenge') return ({
+            userMessage: `❌ The challenge **${oBody.data}** was not found.`, ephemeral: true
+        });
+        else if (oBody.context === 'tournament') return (
+            oBody.data === '(currentTournament)' ? ({
+                userMessage: `❌ The current tournament was not found.`, ephemeral: true
+            }) : ({
+                userMessage: `❌ The tournament **${oBody.data}** was not found.`, ephemeral: true
+            })
+        );
+        else return ({
+            userMessage: `❌ This command failed unexpectedly. **${oBody.data}** does not exist.`, ephemeral: true
+        });
+    }],
+    [OutcomeStatus.FAIL_VALIDATION, (o: JudgeSubmissionOutcome) => {
+        const oBody = (o as OptionValidationErrorOutcome<string>).body;
+        if (oBody.constraint.category === OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS) return ({
+            userMessage: `❌ You are not a judge.`, ephemeral: true
+        });
+        else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_DNE) return ({
+            userMessage: `❌ The tournament **${oBody.value}** was not found.`, ephemeral: true
+        });
+        else return ({
+            userMessage: `❌ This command failed unexpectedly.`, ephemeral: true
+        });
+    }],
+]);
+
+const judgeSubmissionSlashCommandOutcomeDescriber = async (interaction: LimitedCommandInteraction): Promise<SlashCommandDescribedOutcome> => {
+    const outcome = await judgeSubmissionSlashCommandValidator(interaction);
+    if (judgeSubmissionSlashCommandDescriptions.has(outcome.status)) return judgeSubmissionSlashCommandDescriptions.get(outcome.status)!(outcome);
+    // Fallback to trying default descriptions
+    const defaultOutcome = outcome as Outcome<string>;
+    if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
+        return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
+    } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
+};
+
+const judgeSubmissionSlashCommandReplyer = async (interaction: CommandInteraction): Promise<void> => {
+    const describedOutcome = await judgeSubmissionSlashCommandOutcomeDescriber(limitCommandInteraction(interaction));
+    interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
+};
 
 const JudgeSubmissionCommand = new CustomCommand(
     new SlashCommandBuilder()
         .setName('judge-submission')
-        .setDescription('Approve or reject the submission for a challenge from a contestant.')
+        .setDescription('Approve or reject the newest submission for a challenge from a contestant.')
         .addStringOption(option => option.setName('name').setDescription('The name of the challenge.').setRequired(true))
         .addUserOption(option => option.setName('contestant').setDescription('The contestant who submitted the challenge.').setRequired(true))
         .addBooleanOption(option => option.setName('approve').setDescription('Approve the submission with True, reject it with False.').setRequired(true))
+        .addStringOption(option => option.setName('notes').setDescription('Leave a review note or other comment on the submission.').setRequired(false))
         .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is part of. Defaults to current tournament.').setRequired(false)) as SlashCommandBuilder,
     async (interaction: CommandInteraction) => {
-        interaction.reply({ content: 'This command is not yet implemented.', ephemeral: true });
+        await judgeSubmissionSlashCommandReplyer(interaction);
     }
 );
 

--- a/src/commands/slashcommands/architecture/validation.ts
+++ b/src/commands/slashcommands/architecture/validation.ts
@@ -5,7 +5,7 @@ import { ApplicationCommandOptionType, CommandInteractionOption } from 'discord.
 
 export type Constraint<T> = {
     category: OptionValidationErrorStatus;
-    func: (val: T) => boolean;
+    func: (val: T) => Promise<boolean>;
 }
 /**
  * Runs every constraint provided on the metadata fields and options of the (slash command) interaction, throwing an `OptionValidationError` on the first failure.
@@ -13,7 +13,7 @@ export type Constraint<T> = {
  * @param metadataConstraintMap A map of a metadata field of `LimitedCommandInteraction` to a list of one or many `Constraint`s to run on that field.
  * @param optionConstraintMap A map of options of the slash command to a list of one or many `Constraint`s to run on that option.
  */
-export const validateConstraints = (interaction: LimitedCommandInteraction, metadataConstraintMap: Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>, optionConstraintMap: Map<CommandInteractionOption, [Constraint<ValueOf<CommandInteractionOption>>]>): void => {
+export const validateConstraints = (interaction: LimitedCommandInteraction, metadataConstraintMap: Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>, optionConstraintMap: Map<CommandInteractionOption | null, [Constraint<ValueOf<CommandInteractionOption>>]>): void => {
     metadataConstraintMap.forEach((constraints, metadataField) => {
         constraints.forEach((constraint) => {
             if (!constraint.func(interaction[metadataField])) {

--- a/src/commands/slashcommands/architecture/validation.ts
+++ b/src/commands/slashcommands/architecture/validation.ts
@@ -1,0 +1,56 @@
+import { LimitedCommandInteraction } from '../../../types/limitedCommandInteraction.js';
+import { ValueOf } from '../../../types/typelogic.js';
+import { OptionValidationError, OptionValidationErrorStatus } from '../../../types/customError.js';
+import { ApplicationCommandOptionType, CommandInteractionOption } from 'discord.js';
+
+export type Constraint<T> = {
+    category: OptionValidationErrorStatus;
+    func: (val: T) => boolean;
+}
+/**
+ * Runs every constraint provided on the metadata fields and options of the (slash command) interaction, throwing an `OptionValidationError` on the first failure.
+ * @param interaction The `LimitedCommandInteraction` form of a slash command `CommandInteraction`.
+ * @param metadataConstraintMap A map of a metadata field of `LimitedCommandInteraction` to a list of one or many `Constraint`s to run on that field.
+ * @param optionConstraintMap A map of options of the slash command to a list of one or many `Constraint`s to run on that option.
+ */
+export const validateConstraints = (interaction: LimitedCommandInteraction, metadataConstraintMap: Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>, optionConstraintMap: Map<CommandInteractionOption, [Constraint<ValueOf<CommandInteractionOption>>]>): void => {
+    metadataConstraintMap.forEach((constraints, metadataField) => {
+        constraints.forEach((constraint) => {
+            if (!constraint.func(interaction[metadataField])) {
+                throw new OptionValidationError<ValueOf<LimitedCommandInteraction>>(`Validation failed: check ${constraint.category} on metadata field ${metadataField} failed for value ${interaction[metadataField]}.`,
+                    constraint,
+                    metadataField,
+                    interaction[metadataField]);
+            }
+        });
+    });
+
+    optionConstraintMap.forEach((constraints, option) => {
+        // If the option wasn't provided, don't attempt to validate it.
+        if (!option) return;
+
+        // Determine the intended option data based on `option.type`.
+        let optionValue: ValueOf<CommandInteractionOption>;
+        if (option.type === ApplicationCommandOptionType.User) {
+            optionValue = option.user;
+        } else if (option.type === ApplicationCommandOptionType.Channel) {
+            optionValue = option.channel;
+        } else if (option.type === ApplicationCommandOptionType.Role) {
+            optionValue = option.role;
+        } else if (option.type === ApplicationCommandOptionType.String || option.type === ApplicationCommandOptionType.Integer || option.type === ApplicationCommandOptionType.Number || option.type === ApplicationCommandOptionType.Boolean) {
+            optionValue = option.value;
+        } else {
+            throw new Error(`Error in validation.ts: option ${option.name} does not match a supported option type.`);
+        }
+
+        // With the type of the option established, run the constraints on it.
+        constraints.forEach((constraint) => {
+            if (!constraint.func(optionValue)) {
+                throw new OptionValidationError(`Validation failed: check ${constraint.category} on metadata field ${option.name} failed for value ${optionValue}.`,
+                    constraint,
+                    option.name,
+                    optionValue);
+            }
+        });
+    });
+};

--- a/src/commands/submit-challenge.ts
+++ b/src/commands/submit-challenge.ts
@@ -59,7 +59,7 @@ const submitChallenge = async (interaction: CommandInteraction): Promise<void> =
 
     // Fail if contestant already has pending or accepted submission for this challenge
     const submissions = await getSubmissionsForChallengeFromContestant(challenge, contestant);
-    if (submissions && submissions.filter(submission => submission.get('status') !== SubmissionStatus.Rejected).length > 0) {
+    if (submissions && submissions.filter(submission => submission.get('status') !== SubmissionStatus.REJECTED).length > 0) {
         throw new ChallengeSubmissionError(`Submission rejected due to pending or already accepted submission from this member.`, `Your submission was not sent. Your previous submission to this challenge is either waiting to be approved or was already approved.`);
     }
 

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,4 +1,4 @@
-import { Client, Collection } from 'discord.js';
+import { Client, Collection, GatewayIntentBits } from 'discord.js';
 import { CustomCommand } from './customCommand.js';
 
 export type SlashCommandCollectionPair = {
@@ -12,7 +12,9 @@ export class TournamentionClient extends Client {
 
     private constructor() {
         super({
-            intents: [],
+            intents: [
+                GatewayIntentBits.Guilds,
+            ],
         });
         this.commands = new Collection();
         TournamentionClient.instance = this;

--- a/src/types/customError.ts
+++ b/src/types/customError.ts
@@ -1,3 +1,5 @@
+import { Constraint } from '../commands/slashcommands/architecture/validation.js';
+
 export class DuplicateSubdocumentError extends Error {
     constructor(message: string) {
         super(message);
@@ -13,6 +15,47 @@ export class NonexistentGuildError extends Error {
     constructor(public guildID: string) {
         super(`Guild with ID ${guildID} does not exist in the database.`);
         this.name = 'NonexistentGuildError';
+    }
+}
+
+/**
+ * Generic error for when a specified document is not found in the database.
+ * Currently unused in the codebase.
+ */
+export class NonexistentDocumentError extends Error {
+    constructor(public documentId: string) {
+        super(`Document with ID ${documentId} does not exist in the database.`);
+        this.name = 'NonexistentDocumentError';
+    }
+}
+
+/**
+ * Error for when a document in a model compound-indexed by guild ID and user ID is not found.
+ */
+export class NonexistentJointGuildAndMemberError extends Error {
+    constructor(public guildId: string, public memberId: string) {
+        super(`Document with guild ID of ${guildId} and member of ID ${memberId} does not exist.`);
+        this.name = 'NonexistentJointGuildAndMemberError';
+    }
+}
+
+/**
+ * Categories of validation errors, where each category's name is a fail scenario if true.
+ * For example, the category INSUFFICIENT_PERMISSIONS is straightforwardly a fail scenario 
+ * and has no opposite (i.e. having permissions to use a command would never be a fail scenario),
+ * whereas the category TARGET_USER_BOT is used to indicate that the target user is a bot but SHOULD
+ * NOT be, rather than the opposite (which would be labelled TARGET_USER_NOT_BOT).
+ */
+export enum OptionValidationErrorStatus {
+    INSUFFICIENT_PERMISSIONS = 'INSUFFICIENT_PERMISSIONS', // user's permissions are insufficient to use the command
+    TARGET_USER_BOT = 'TARGET_USER_BOT', // target user is a bot (but should not be)
+    NUMBER_BEYOND_RANGE = 'NUMBER_BEYOND_RANGE', // number is outside of the required range
+}
+
+export class OptionValidationError<T> extends Error {
+    constructor(message: string, public readonly constraint: Constraint<T>, public readonly field: string, public readonly value: T) {
+        super(message);
+        this.name = 'OptionValidationError';
     }
 }
 
@@ -35,5 +78,15 @@ export class UserMessageError extends UserFacingError {
     constructor(message: string, userMessage: string) {
         super(message, userMessage);
         this.name = 'UserMessageError';
+    }
+}
+
+/**
+ * An error thrown for inexplicable situations, such as APIs returning unexpected data.
+ */
+export class UnknownError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'UnknownError';
     }
 }

--- a/src/types/customError.ts
+++ b/src/types/customError.ts
@@ -50,6 +50,7 @@ export enum OptionValidationErrorStatus {
     INSUFFICIENT_PERMISSIONS = 'INSUFFICIENT_PERMISSIONS', // user's permissions are insufficient to use the command
     TARGET_USER_BOT = 'TARGET_USER_BOT', // target user is a bot (but should not be)
     NUMBER_BEYOND_RANGE = 'NUMBER_BEYOND_RANGE', // number is outside of the required range
+    OPTION_DNE = 'OPTION_DNE', // option's associated data does not exist
 }
 
 export class OptionValidationError<T> extends Error {

--- a/src/types/defaultSlashCommandDescriptions.ts
+++ b/src/types/defaultSlashCommandDescriptions.ts
@@ -1,35 +1,30 @@
 import { OutcomeStatus, Outcome, SlashCommandDescribedOutcome, OutcomeWithMonoBody, OutcomeWithDuoBody } from './outcome.js';
 
 export const defaultSlashCommandDescriptions = new Map<OutcomeStatus, (o: Outcome<string>) => SlashCommandDescribedOutcome>([
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.SUCCESS, (_: Outcome<string>) => {
         return {
             userMessage: '✅ Success!',
             ephemeral: true,
         };
     }],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.SUCCESS_MONO, (_: Outcome<string>) => {
         return {
             userMessage: `✅ Success! (default response, 1 data point omitted)`,
             ephemeral: true,
         };
     }],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.SUCCESS_DUO, (_: Outcome<string>) => {
         return {
             userMessage: `✅ Success! (default response, 2 data points omitted)`,
             ephemeral: true,
         };
     }],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.SUCCESS_NO_CHANGE, (_: Outcome<string>) => {
         return {
             userMessage: `✅ Success! However, certain operations made no changes.`,
             ephemeral: true,
         };
     }],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.FAIL, (_: Outcome<string>) => {
         return {
             userMessage: '❌ This command failed.',
@@ -54,7 +49,6 @@ export const defaultSlashCommandDescriptions = new Map<OutcomeStatus, (o: Outcom
             ephemeral: true,
         };
     }],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.FAIL_UNKNOWN, (_: Outcome<string>) => {
         return {
             userMessage: '❌ This command failed for an unknown reason.',

--- a/src/types/defaultSlashCommandDescriptions.ts
+++ b/src/types/defaultSlashCommandDescriptions.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { OutcomeStatus, Outcome, SlashCommandDescribedOutcome, OutcomeWithMonoBody, OutcomeWithDuoBody } from './outcome.js';
+
+export const defaultSlashCommandDescriptions = new Map<OutcomeStatus, (o: Outcome<string>) => SlashCommandDescribedOutcome>([
+    [OutcomeStatus.SUCCESS, (_: Outcome<string>) => {
+        return {
+            userMessage: '✅ Success!',
+            ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.SUCCESS_MONO, (_: Outcome<string>) => {
+        return {
+            userMessage: `✅ Success! (default response, 1 data point omitted)`,
+            ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.SUCCESS_DUO, (_: Outcome<string>) => {
+        return {
+            userMessage: `✅ Success! (default response, 2 data points omitted)`,
+            ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.SUCCESS_NO_CHANGE, (_: Outcome<string>) => {
+        return {
+            userMessage: `✅ Success! However, certain operations made no changes.`,
+            ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.FAIL, (_: Outcome<string>) => {
+        return {
+            userMessage: '❌ This command failed.',
+            ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.FAIL_VALIDATION, (o: Outcome<string>) => {
+        return {
+            userMessage: `❌ This command failed due to entered data ${(o as OutcomeWithMonoBody<string>).body.data}`,
+            ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.FAIL_DNE_MONO, (o: Outcome<string>) => {
+        return {
+            userMessage: `❌ This command failed because the data ${(o as OutcomeWithMonoBody<string>).body.data} could not be found.`,
+            ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.FAIL_DNE_DUO, (o: Outcome<string>) => {
+        return {
+            userMessage: `❌ This command failed because ${(o as OutcomeWithDuoBody<string>).body.data1} and ${(o as OutcomeWithDuoBody<string>).body.data2} do not exist together.`,
+            ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.FAIL_UNKNOWN, (_: Outcome<string>) => {
+        return {
+            userMessage: '❌ This command failed for an unknown reason.',
+            ephemeral: true,
+        };
+    }],
+]);

--- a/src/types/defaultSlashCommandDescriptions.ts
+++ b/src/types/defaultSlashCommandDescriptions.ts
@@ -1,31 +1,35 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { OutcomeStatus, Outcome, SlashCommandDescribedOutcome, OutcomeWithMonoBody, OutcomeWithDuoBody } from './outcome.js';
 
 export const defaultSlashCommandDescriptions = new Map<OutcomeStatus, (o: Outcome<string>) => SlashCommandDescribedOutcome>([
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.SUCCESS, (_: Outcome<string>) => {
         return {
             userMessage: '✅ Success!',
             ephemeral: true,
         };
     }],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.SUCCESS_MONO, (_: Outcome<string>) => {
         return {
             userMessage: `✅ Success! (default response, 1 data point omitted)`,
             ephemeral: true,
         };
     }],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.SUCCESS_DUO, (_: Outcome<string>) => {
         return {
             userMessage: `✅ Success! (default response, 2 data points omitted)`,
             ephemeral: true,
         };
     }],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.SUCCESS_NO_CHANGE, (_: Outcome<string>) => {
         return {
             userMessage: `✅ Success! However, certain operations made no changes.`,
             ephemeral: true,
         };
     }],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.FAIL, (_: Outcome<string>) => {
         return {
             userMessage: '❌ This command failed.',
@@ -50,6 +54,7 @@ export const defaultSlashCommandDescriptions = new Map<OutcomeStatus, (o: Outcom
             ephemeral: true,
         };
     }],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [OutcomeStatus.FAIL_UNKNOWN, (_: Outcome<string>) => {
         return {
             userMessage: '❌ This command failed for an unknown reason.',

--- a/src/types/limitedCommandInteraction.ts
+++ b/src/types/limitedCommandInteraction.ts
@@ -1,0 +1,22 @@
+import { Snowflake, GuildMember, CommandInteraction, InteractionType, APIInteractionGuildMember } from 'discord.js';
+import { CommandInteractionOptionResolverAlias } from './discordTypeAlias.js';
+
+export type LimitedCommandInteraction = {
+    id: Snowflake;
+    commandId: Snowflake;
+    guildId: Snowflake | null;
+    member: GuildMember | APIInteractionGuildMember | null;
+    options: CommandInteractionOptionResolverAlias;
+    type: InteractionType;
+};
+
+export const limitCommandInteraction = (interaction: CommandInteraction): LimitedCommandInteraction => {
+    const limitedCommandInteraction = {
+        ...interaction
+    };
+    if (!limitedCommandInteraction.guildId || !limitedCommandInteraction.member) {
+        console.error(`Error in limitedCommandInteraction.ts: ${interaction}`);
+        throw new Error('Command interaction is missing guild ID or member. Only slash commands in guilds are supported.');
+    }
+    return limitedCommandInteraction;
+};

--- a/src/types/outcome.ts
+++ b/src/types/outcome.ts
@@ -1,0 +1,60 @@
+import { Constraint } from '../commands/slashcommands/architecture/validation.js';
+
+export type SlashCommandDescribedOutcome = {
+    userMessage: string,
+    ephemeral: boolean,
+};
+
+export enum OutcomeStatus {
+    SUCCESS = 'SUCCESS', // generic success
+    SUCCESS_NO_CHANGE = 'SUCCESS_NO_CHANGE', // trivial success with no change
+    SUCCESS_MONO = 'SUCCESS_MONO', // success with one datapoint
+    SUCCESS_DUO = 'SUCCESS_DUO', // success with two datapoints
+    FAIL = 'FAIL', // generic failure
+    FAIL_VALIDATION = 'FAIL_VALIDATION', // premature failure due to validation error
+    FAIL_DNE_MONO = 'FAIL_DNE_MONO', // nonexistence failure with one datapoint, indicating that the target does not exist
+    FAIL_DNE_DUO = 'FAIL_DNE_DUO', // nonexistencec failure with two datapoints, indicating that the joint target does not exist
+    FAIL_UNKNOWN = 'FAIL_UNKNOWN', // failure with unknown reason
+}
+
+// Shorthand for the enforced empty object type.
+type EmptyObject = Record<string, never>;
+
+export type OutcomeWithEmptyBody = {
+    status: OutcomeStatus.SUCCESS | OutcomeStatus.FAIL | OutcomeStatus.FAIL_UNKNOWN,
+    body: EmptyObject,
+};
+
+export type OutcomeWithMonoBody<T> = {
+    status: OutcomeStatus.SUCCESS_MONO | OutcomeStatus.FAIL_DNE_MONO,
+    body: {
+        data: T,
+    },
+};
+
+export type OutcomeWithDuoBody<T> = {
+    status: OutcomeStatus.SUCCESS_DUO | OutcomeStatus.FAIL_DNE_DUO,
+    body: {
+        data1: T,
+        data2: T,
+    },
+};
+
+export type OptionValidationErrorOutcome<T> = {
+    status: OutcomeStatus.FAIL_VALIDATION,
+    body: {
+        constraint: Constraint<T>,
+        field: string,
+        value: T,
+    },
+};
+
+export type OutcomeWithDuoListBody<T, U> = {
+    status: OutcomeStatus.SUCCESS_NO_CHANGE,
+    body: {
+        data1: T[],
+        data2: U[],
+    },
+};
+
+export type Outcome<T, U = void> = OutcomeWithEmptyBody | OutcomeWithMonoBody<T> | OutcomeWithDuoBody<T> | OutcomeWithDuoListBody<T, U> | OptionValidationErrorOutcome<T>;

--- a/src/types/outcome.ts
+++ b/src/types/outcome.ts
@@ -29,6 +29,7 @@ export type OutcomeWithMonoBody<T> = {
     status: OutcomeStatus.SUCCESS_MONO | OutcomeStatus.FAIL_DNE_MONO,
     body: {
         data: T,
+        context: string,
     },
 };
 
@@ -36,7 +37,9 @@ export type OutcomeWithDuoBody<T> = {
     status: OutcomeStatus.SUCCESS_DUO | OutcomeStatus.FAIL_DNE_DUO,
     body: {
         data1: T,
+        context1: string,
         data2: T,
+        context2: string,
     },
 };
 
@@ -46,6 +49,7 @@ export type OptionValidationErrorOutcome<T> = {
         constraint: Constraint<T>,
         field: string,
         value: T,
+        context: string,
     },
 };
 
@@ -53,7 +57,9 @@ export type OutcomeWithDuoListBody<T, U> = {
     status: OutcomeStatus.SUCCESS_NO_CHANGE,
     body: {
         data1: T[],
+        context1: string,
         data2: U[],
+        context2: string,
     },
 };
 

--- a/src/types/typelogic.ts
+++ b/src/types/typelogic.ts
@@ -1,0 +1,5 @@
+
+/**
+ * Provided an object type, this represents the union of its properties' values.
+ */
+export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
Closes #23, #24, #52

Guided by a better and better instinct towards more SOLID patterns, I've been getting closer to making the slash commands as well-designed as possible; perhaps excessively so. I'm specifically talking about the [Single Responsibility Principle](https://en.wikipedia.org/wiki/Single-responsibility_principle) and how it relates to the architecture of a slash command throughout this writeup. You can actually see my progression moving chronologically from `create-tournament` to `edit-challenge` to `submit-challenge`. I intend to go back and refactor all commands to use some pattern, but that first requires me to formalize what it is I'm doing and why -- and to reconcile that with the main concerns I've had about a fitting architecture for commands: passing back more specific details from deep in the call stack and compatibility with other distinct kinds of "frontends" for the same feature (like a slash command versus a right-click-on-message command versus a hypothetical web interface versus REST API). Clearly, these must be problems with existing solutions in software out there, and I know the latter isn't hard, but what the heck to do about the former?

<a id="elaborate"><details><summary>Still confused about what problem I was trying to solve?</summary>
<hr />
<p>Again, we're talking about how to get data resulting from the finished (or failed) business logic back to the frontend. You can't just send back a string that provides what should be sent to the frontend verbatim. How do you generalize and abstract the data returned?</p>
<p>Here's an analogous example -- a REST API: suppose we want to `POST` data `a` and `b` to `/bar`. There's a number of ways, each, this can go wrong or right. Are `a` or `b` of the wrong type or format? Are `a` and `b` incompatible with each other? Are `a` and `b` compatible, while `b` is incompatible with other existing data `c`? Given the possibilities, what abstraction can we use to share intended next behavior between outcomes of `/bar`, let alone outcomes of any endpoint? How do we give the pieces needed to describe the outcome to the end user to the middle layers which send it without relying on the backend to write it up?</p>
<p>As I endeavored to find a canonical, SOLID solution that comfortably addressed that concern, I failed to find a design pattern capable of abstracting the universe of possible outcomes, even for just one particular feature's outcomes. While I won't say it's because it's impossible to do, I will again gesture to REST APIs to demonstrate that <i>no one does this.</i> There is no general-purpose specification because it's far too complex. What do REST APIs send back? Standardized response codes, and totally idiosyncratic body data.</p>
<p><i>At this point, I suggest reading the pseudocode and commentary below for context, if you haven't.</i></p>
<p>That's it, then! When sending data back from `foo` up to `fooSlashCommandDescriber`, I'd use some enumeration of outcomes for `foo` -- analogous to a response code -- and idiosyncratic set of properties and values to convey additional information -- analogous to body fields and values -- bundled together in a one of many highly-specific interfaces. This great revelation doesn't really sound like much of one in hindsight, but it's key to getting over my need for some high-quality solution. There will be many, many interfaces, each specific to some outcome of using feature "foo", and that's okay.
<hr />
</details></a>

This got pretty long so I added emojis to help stimulate your noggin.

🤔💭 I've envisioned a quite ideal form of a SOLID Discord slash command architecture for the representative "foo" feature as follows, just one of many kinds of frontends for shared core features of the bot:
```typescript
const fooSlashCommand = new CustomCommand(
  /* ... SlashCommandBuilder ... */,
  async (interaction: CommandInteraction) => {
    await fooSlashCommandReplyer(interaction);
  }
);
```
😮 And that's it for the function! It may seem extreme or like kicking the can down the road, but bear with me. This adheres to the SRP in that the only reason for this to change is for a change to the command arguments, i.e. the SlashCommandBuilder stuff.

```typescript
const fooSlashCommandReplyer = async (interaction: CommandInteraction): Promise<void> => {
  const describedOutcome = await fooSlashCommandOutcomeDescriber(limitCommandInteraction(interaction));
  interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
});
```

👏 Again, simple in this step, but that's because the Discord.js library does a lot for us. Another frontend's needs could be more complex. SRP here mandates here the only reason for `fooSlashCommandReplyer` to change is a change to the usage of the Discord.js library... well, sort of: that `limitCommandInteraction` just strips all but the necessary members from CommandInteraction as a least-privilege measure and to make replying further down the stack impossible. It's not important to the concept here.

🧩 You'll probably notice a rigid format for any `barSlashCommand`, `barSlashCommandReplyer`, and other pieces of the architecture emerging, and yes, we'll move towards using the beneficial OO principles later. This is just a case study on feature "foo" for now, matching the code used to complete the features in this PR.

💻📱📠 We still haven't departed from a space tightly coupled to the Discord slash command frontend, but you can (and should, because it's coming) imagine a quite different way of handling the results from any other `fooOtherFrontEndOutcomeDescriber` -- be that in a web interface, whatever's possible in the new "Message Commands" and "User Commands" in Discord, etc. A REST API would basically just be sending the JSON passed up from the describer to the user over HTTP, for example.

```typescript
// pseudocode, it's a bit more complicated in practice
const fooOutcomeSlashCommandDescriptions = new Map<FooStatus, (o: FooOutcome) => SlashCommandDescribedOutcome>([
  [FooOutcome.SUCCESS_1, (o: FooOutcome) => ({ userMessage: '✅ Foo barred!', ephemeral: true })],
  [FooOutcome.SUCCESS_2, (o: FooOutcome) => ({ userMessage: `✅ ${o.body.user} fooed bar ${o.body.target} successfully!`, ephemeral: true })],
  [FooOutcome.FAIL_1, (o: FooOutcome) => ({ userMessage: `❌ Foo was not barred. Value ${o.body.valueOne} is incompatible with ${o.body.valueTwo}.`, ephemeral: true })],
  /* ... */
);

const fooSlashCommandOutcomeDescriber = async (interaction: LimitedCommandInteraction): Promise<SlashCommandDescribedOutcome> => {
  const outcome = await fooSlashCommandValidator(interaction);
  if (fooOutcomeSlashCommandDescriptions.has(outcome.status)) return fooOutcomeSlashCommandDescriptions.get(outcome.status)!(outcome);
  // Fallback to trying default descriptions
  const defaultOutcome = outcome as Outcome<string>;
  if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
      return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
  } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
};
```

👥 The term "outcome" is doing double-duty here in a conceptual sense, as you'll see with `SlashCommandDescribedOutcome` and `FooOutcome`. Whereas the latter is a "foo"-feature-specific blob of information (what/why/when/etc. across multiple possible fields) understood by any `fooSomeFrontEndOutcomeDescriber`, the former is an interface accepted by all `SlashCommandReplyer`s that provides members `userMessage: string` and `ephemeral: boolean` to inform them how to reply. The SR of this step is creating exactly that. For any `fooSomeFrontEndOutcomeDescriber`, the only task is to define a medium-appropriate description of what information to send back out regarding the success or failure. This code would be changed only to alter how it responds to some outcome, and it only needs to be changed in exactly one place.

🗺️ Making the Map's value a function rather than a string is what allows dynamic description definitions with little added syntactic complexity. Once the outcome's status is matched with one of the predefined description patterns, the value for that key is invoked with the outcome itself and the finalized description string is constructed using the data in the outcome body. Having these default Outcome types allows rapid prototyping of new commands in this system without the need to tear initial code down later, as well as reducing the amount of effectively identical Outcomes specific to some `foo` command just to encompass the general-case result descriptions. You'll see more on that below.

```typescript
const fooSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<FooOutcome> => {
  // Validation logic goes here,
  // returning a new failure FooOutcome before even calling foo when validation fails.
  // Notice this is the only place where interaction's members are looked at before
  // being sent off to foo.

  return await foo(/* ... args ... */);
};
```

⬛ True to its name, the SR of this step is validation logic on the interaction's data. Validation logic may be shorter or longer, depending on feature "foo"'s requirements. In my implementation, sophisticated "constraint validation" logic is used here, which requires its own page of documentation. For the discussion on this architecture, it can just be black-boxed.

```typescript
// in src/types/outcome.ts
export type SlashCommandDescribedOutcome = {
  userMessage: string,
  ephemeral: boolean,
};

export enum OutcomeStatus {
  SUCCESS = 'SUCCESS', // generic success
  SUCCESS_MONO = 'SUCCESS_MONO', // success with one datapoint
  // ... other more specific SUCCESS outcomes with different data ...
  FAIL = 'FAIL', // generic failure
  FAIL_VALIDATION = 'FAIL_VALIDATION', // premature failure due to validation error
  FAIL_DNE_MONO = 'FAIL_DNE_MONO', // nonexistence failure with one datapoint, indicating that the target does not exist
  // ... other more specific FAIL outcomes with different data ...
  FAIL_UNKNOWN = 'FAIL_UNKNOWN', // failure with unknown reason
}

export type OutcomeWithEmptyBody = {
    status: OutcomeStatus.SUCCESS | OutcomeStatus.FAIL | OutcomeStatus.FAIL_UNKNOWN,
    body: {},
};

export type OutcomeWithMonoBody<T> = {
    status: OutcomeStatus.SUCCESS_MONO | OutcomeStatus.FAIL_DNE_MONO,
    body: {
        data: T,
    },
};

// ... other outcome types ...

// union all outcomes for the composite Outcome type
export type Outcome<T> = OutcomeWithEmptyBody | OutcomeWithMonoBody<T> /* | ... other outcome types ... */;

// back in src/commands/foo.ts
enum FooSpecificStatus {
  SUCCESS_1,
  SUCCESS_2,
  FAIL_1,
  /* ... */
}

// union foo-specific statuses and general outcome statuses for an umbrella status composite type
type FooStatus = FooSpecificStatus | OutcomeStatus;

type FooSuccess1Outcome = {
  status: FooSpecificStatus.SUCCESS_1,
  body: {
    // ... some data ...
  },
}

// ... other foo-specific outcomes ...

// union foo-specific outcomes and general outcomes for an umbrella outcome composite type
type FooOutcome = FooSuccess1Outcome | /* ... other foo-specific outcomes ... */ | Outcome<string>;

const foo = async (/* ... args ... */): FooOutcome => {
  // business logic

  return outcome;
};
```

👧🏼🐻🐻🐻 We have some general Outcomes that includes the unknown error, simple OK, or other universal outcomes, as well as outcomes defined specifically for `foo`. This makes `FooOutcome` is as granular as needed, with the ability to capture any possible outcome scenario and be later used as a specification for the describer. There's probably an OO parallel to how this works, but I love this because it is leveraging a feature quite unique to TypeScript over something like Java, which is the robust type system much like what you'd see in a native functional programming language. JavaScript was originally made as a functional programming language, after all 😄. In this case, we are using composite types to rely on elsewhere to specify expectations and control logic flow with rigid type checking. It's intractable in plain JavaScript and Java alike -- we're in the Goldilocks zone with TypeScript!

📜 Notice that in our example some outcomes would probably provide some data like `user` and `target`. Information like this could almost certainly be retrieved directly from the `interaction` in the describer-space, but this must be avoided for the SRP and Open/Closed Principle to be followed! It's best to let everything be provided by the outcome object. Said succinctly, this protects the higher rungs of the architecture from being coupled to underlying implementation and thus breaking upon small changes.

---

And that's the architecture template of a slash command written to adhere closely to SOLID principles. Of course, it's not truly final -- there'd be a lot of repeated code if I had these as totally separate functions for features "foo", "bar", "baz", and so on. With a bit more abstraction, the end result would be a minimal-code DX for defining a slash command's frontend with a declarative, fill-in-the-blanks syntax (someone should make a library out of this!). In concept, though, this is sufficient for any slash command use case and ensures any one change to the architecture, should it occur, only needs to happen in one place in the codebase, whereas changes to one command also happen in only one place for that command.

I'll be throwing this on the wiki along with a graphic to document the architecture we'll use from now on (#47).

---

To update for the week of 10/2, when we're finally merging this PR, I wanted to say that the command architecture described here broadly is great, and I was able to implement it in a non-generalized (i.e. POC, not OO as eventually planned) fashion, along with some other useful constructs last week. Where my work has been bogged down is in designing a robust validation logic system. Implementing that was much more intensive, particularly as I applied the design to a more complicated command like #24's requirements. This will come with its own whole slew of documentation, since it's about as complex in itself as everything else in the architecture put together. Like the command architecture overall, it is only be ready in a POC form for this PR.

Though some implementations definitely require later refactors, the features are now fully viable and ready to be shipped!