### PR TITLE
Add tournament list command. Convert /submit-challenge, /create-challenge to new architecture

### DIFF
--- a/src/backend/queries/challengeQueries.ts
+++ b/src/backend/queries/challengeQueries.ts
@@ -3,6 +3,7 @@ import { ChallengeDocument, TournamentDocument } from '../../types/customDocumen
 import { Challenge, ChallengeModel } from '../schemas/challenge.js';
 import { UpdateChallengeParams } from '../../types/apiPayloadObjects.js';
 import { Ref } from '@typegoose/typegoose';
+import { Tournament, TournamentModel } from '../schemas/tournament.js';
 // CREATE / POST
 
 // READ / GET
@@ -15,6 +16,11 @@ export const getChallengeOfTournamentByName = async (name: string, tournament: T
     // Use Mongoose's query builder to filter for Challenges with both the matching name and
     // membership in the tournament's challenge.
     return ChallengeModel.findOne().where('_id').in(tournament.challenges).where('name').equals(name).exec();
+};
+
+export const getChallengesOfTournament = async (tournamentId: Ref<Tournament> | string): Promise<ChallengeDocument[]> => {
+    const tournament = await TournamentModel.findById(tournamentId);
+    return ChallengeModel.find().where('_id').in(tournament!.challenges).exec();
 };
 
 // UPDATE / PUT

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -115,6 +115,11 @@ export const getDifficultyByEmoji = async (tournament: TournamentDocument, emoji
     return null;
 };
 
+export const getDifficultiesOfTournament = async (tournamentId: Ref<Tournament> | string): Promise<DifficultyDocument[]> => {
+    const tournament = await TournamentModel.findById(tournamentId);
+    return DifficultyModel.find().where('_id').in(tournament!.difficulties).exec();
+};
+
 // UPDATE / PUT
 export const updateTournament = async (id: ObjectId, update: UpdateTournamentParams): Promise<TournamentDocument | null> => {
     return TournamentModel.findByIdAndUpdate(id, { $set: update });

--- a/src/backend/schemas/guildsettings.ts
+++ b/src/backend/schemas/guildsettings.ts
@@ -11,11 +11,13 @@ export class GuildSettings {
 
     public async getCurrentTournament(): Promise<TournamentDocument | null> {
         // TODO: test performance WRT frequent .toObject() calls, would a separate array of Tournament be faster?
-        const guildTournaments = (await TournamentModel.find({ guildID: this.guildID }));
-        const activeTournament = guildTournaments
+        const guildTournaments = await TournamentModel.find({ guildID: this.guildID });
+        const activeTournaments = guildTournaments
             .filter((t: TournamentDocument) => {
                 return t.toObject().active;
-            })
+            });
+        if (activeTournaments.length === 0) return null;
+        const currentTournament = activeTournaments
             .reduce((prev: TournamentDocument, curr: TournamentDocument) => {
                 const prevTournament: Tournament = prev.toObject();
                 const currTournament: Tournament = curr.toObject();
@@ -23,7 +25,7 @@ export class GuildSettings {
                     && prevTournament._id.getTimestamp().getTime() > currTournament._id.getTimestamp().getTime() 
                     ? prev : curr;
             });
-        return activeTournament ? activeTournament : null;
+        return currentTournament;
     }
 }
 

--- a/src/commands/assign-judge.ts
+++ b/src/commands/assign-judge.ts
@@ -109,7 +109,7 @@ const assignJudgeSlashCommandValidator = async (interaction: LimitedCommandInter
 
     const who = interaction.options.get('who', true);
 
-    const metadataConstraints = new Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>([
+    const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([
         ['member', [
             // Ensure that the sender is an Administrator
             {
@@ -121,7 +121,7 @@ const assignJudgeSlashCommandValidator = async (interaction: LimitedCommandInter
         ]]
     ]);
 
-    const optionConstraints = new Map<CommandInteractionOption, [Constraint<ValueOf<CommandInteractionOption>>]>([
+    const optionConstraints = new Map<CommandInteractionOption, Constraint<ValueOf<CommandInteractionOption>>[]>([
         [who, [
             // Ensure that the target is not a bot
             {

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -157,7 +157,7 @@ const judgeSubmission = async (guildId: string, challengeName: string, contestan
 const judgeSubmissionSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<JudgeSubmissionOutcome> => {
     const guildId = interaction.guildId!;
 
-    const metadataConstraints = new Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>([
+    const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([
         ['member', [
             // Ensure that the sender is a Judge or Administrator
             {
@@ -173,7 +173,7 @@ const judgeSubmissionSlashCommandValidator = async (interaction: LimitedCommandI
     const contestant = interaction.options.get('contestant', true);
     const tournament = interaction.options.get('tournament', false);
 
-    const optionConstraints = new Map<CommandInteractionOption | null, [Constraint<ValueOf<CommandInteractionOption>>]>([
+    const optionConstraints = new Map<CommandInteractionOption | null, Constraint<ValueOf<CommandInteractionOption>>[]>([
         [tournament, [
             // Ensure that the tournament exists, if it was provided
             {

--- a/src/commands/slashcommands/architecture/validation.ts
+++ b/src/commands/slashcommands/architecture/validation.ts
@@ -13,7 +13,7 @@ export type Constraint<T> = {
  * @param metadataConstraintMap A map of a metadata field of `LimitedCommandInteraction` to a list of one or many `Constraint`s to run on that field.
  * @param optionConstraintMap A map of options of the slash command to a list of one or many `Constraint`s to run on that option.
  */
-export const validateConstraints = async (interaction: LimitedCommandInteraction, metadataConstraintMap: Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>, optionConstraintMap: Map<CommandInteractionOption | null, [Constraint<ValueOf<CommandInteractionOption>>]>): Promise<void> => {
+export const validateConstraints = async (interaction: LimitedCommandInteraction, metadataConstraintMap: Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>, optionConstraintMap: Map<CommandInteractionOption | null, Constraint<ValueOf<CommandInteractionOption>>[]>): Promise<void> => {
     // Using for ... of syntax because forEach does not support async functions.
     for (const [metadataField, constraints] of metadataConstraintMap) {
         for (const constraint of constraints) {

--- a/src/commands/submit-challenge.ts
+++ b/src/commands/submit-challenge.ts
@@ -1,86 +1,243 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
-import { CommandInteraction } from 'discord.js';
+import { CommandInteraction, CommandInteractionOption } from 'discord.js';
 import { CustomCommand } from '../types/customCommand.js';
 import { getTournamentByName } from '../backend/queries/tournamentQueries.js';
-import { SubmissionDocument, TournamentDocument } from '../types/customDocument.js';
+import { SubmissionDocument } from '../types/customDocument.js';
 import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
 import { getChallengeOfTournamentByName } from '../backend/queries/challengeQueries.js';
-import { UserFacingError } from '../types/customError.js';
+import { OptionValidationError, OptionValidationErrorStatus } from '../types/customError.js';
 import { getOrCreateContestant } from '../backend/queries/profileQueries.js';
 import { createSubmission, getSubmissionsForChallengeFromContestant } from '../backend/queries/submissionQueries.js';
 import { SubmissionStatus } from '../backend/schemas/submission.js';
+import { OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeWithDuoBody, OutcomeWithMonoBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
+import { LimitedCommandInteraction, limitCommandInteraction } from '../types/limitedCommandInteraction.js';
+import { ValueOf } from '../types/typelogic.js';
+import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
+import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
 
-class ChallengeSubmissionError extends UserFacingError {
-    constructor(message: string, userMessage: string) {
-        super(message, userMessage);
-        this.name = 'ChallengeSubmissionError';
-    }
+/**
+ * Status codes specific to this command.
+ */
+enum SubmitChallengeSpecificStatus {
+    FAIL_TOURNAMENT_INACTIVE = 'FAIL_TOURNAMENT_INACTIVE',
+    FAIL_TOURNAMENT_HIDDEN = 'FAIL_TOURNAMENT_HIDDEN',
+    FAIL_CHALLENGE_HIDDEN = 'FAIL_CHALLENGE_HIDDEN',
+    FAIL_EXISTING_SUBMISSION = 'FAIL_EXISTING_SUBMISSION',
 }
 
-const submitChallenge = async (interaction: CommandInteraction): Promise<void> => {
-    // Use the specified tournament if provided. Otherwise attempt to use the current tournament, failing if there is none.
-    const tournamentName = interaction.options.get('tournament', false)?.value as string ?? '';
-    let tournament: TournamentDocument | null;
-    if (tournamentName) {
-        // A tournament was specified -- use it
-        tournament = await getTournamentByName(interaction.guildId!, tournamentName);
-        if (!tournament) throw new ChallengeSubmissionError(`Tournament ${tournamentName} not found in guild ${interaction.guildId}.`, `Your submission was not sent. That tournament, **${tournamentName}**, was not found.`);
-    } else {
-        // No tournament was specified...
-        const currentTournament = await getCurrentTournament(interaction.guildId!);
-        if (currentTournament) {
-            // ... and there is a current tournament -- use it...
-            tournament = currentTournament;
-            // ...unless it is hidden!
-            if (!tournament.visibility) throw new ChallengeSubmissionError(`Tournament ${tournament.name} is hidden.`, `Your submission was not sent. The current tournament is currently hidden and is not accepting submissions.`);
-        } else {
-            // ... and there is no current tournament -- fail
-            throw new ChallengeSubmissionError(`Guild ${interaction.guildId} has no current tournament.`, 'Your submission was not sent. There is no current tournament.');
-        }
-    }
-    const challengeName = interaction.options.get('name', true).value as string;
-    const challenge = await getChallengeOfTournamentByName(challengeName, tournament);
-    if (!challenge) throw new ChallengeSubmissionError(`Challenge ${challengeName} not found in tournament ${tournament.name}.`, `Your submission was not sent. That challenge, **${challengeName}**, was not found in the tournament **${tournament.name}**.`);
+/**
+ * Union of specific and generic status codes.
+ */
+type SubmitChallengeStatus = SubmitChallengeSpecificStatus | OutcomeStatus;
 
-    // Fail if the tournament or challenge is not active
-    if (!tournament.active) throw new ChallengeSubmissionError(`Tournament ${tournament.name} is not active.`, `Your submission was not sent. That tournament, **${tournament.name}**, is not accepting submissions.`);
-    if (!challenge.visibility) {
-        throw new ChallengeSubmissionError(`Challenge ${challenge.name} is not active.`, `Your submission was not sent. That challenge is currently hidden and is not accepting submissions.`);
-    }
+/**
+ * The outcome format for the specific status code(s).
+ * Since all can reuse the same body format, they are all combined into one type, to later be
+ * discriminated by the status code.
+ */
+type SubmitChallengeSpecificOutcome = {
+    status: SubmitChallengeSpecificStatus.FAIL_TOURNAMENT_INACTIVE | SubmitChallengeSpecificStatus.FAIL_TOURNAMENT_HIDDEN | SubmitChallengeSpecificStatus.FAIL_CHALLENGE_HIDDEN | SubmitChallengeSpecificStatus.FAIL_EXISTING_SUBMISSION;
+    body: {
+        data: string;
+    };
+};
 
-    // Check contestant status -- for now, just getOrCreate them... TODO
-    const contestant = await getOrCreateContestant(interaction.guildId!, interaction.user.id);
+/**
+ * Union of specific and generic outcomes.
+ */
+type SubmitChallengeOutcome = SubmitChallengeSpecificOutcome | Outcome<string>;
 
-    // Fail if no proof was provided
-    const proofLink = interaction.options.get('proof-link', true).value as string;
-    if (!proofLink) {
-        throw new ChallengeSubmissionError(`No proof was provided.`, `Your submission was not sent. You must provide one form proof of your completion of the challenge.`);
-    }
-
-    // Fail if contestant already has pending or accepted submission for this challenge
-    const submissions = await getSubmissionsForChallengeFromContestant(challenge, contestant);
-    if (submissions) {
-        // Using for ... of syntax since filter does not support async functions
-        // (Promise<false> is truthy because any Promise is truthy)
-        const nonRejectedSubmissions = new Array<SubmissionDocument>();
-        for (const submission of submissions) {
-            if (await submission.get('status') !== SubmissionStatus.REJECTED) {
-                nonRejectedSubmissions.push(submission);
-            }
-        }
-        if (nonRejectedSubmissions.length > 0) {
-            throw new ChallengeSubmissionError(`Submission rejected due to pending or already accepted submission from this member.`, `Your submission was not sent. Your previous submission to this challenge is either waiting to be approved or was already approved.`);
-        }
-    }
-
+const submitChallenge = async (guildId: string, challengeName: string, contestantId: string, proofLink: string, tournamentName?: string): Promise<SubmitChallengeOutcome> => {
     try {
-        await createSubmission(challenge, contestant, proofLink);
-    } catch (err) {
-        if (err instanceof UserFacingError) {
-            throw new ChallengeSubmissionError(`Error in submit-challenge.ts: ${err.message}`, err.userMessage);
+        // Ensure the Tournament and Challenge exist
+        const tournament = tournamentName ? await getTournamentByName(guildId, tournamentName) : await getCurrentTournament(guildId);
+        if (!tournament) return ({
+            status: OutcomeStatus.FAIL_DNE_MONO,
+            body: {
+                data: tournamentName ? tournamentName : '(currentTournament)',
+                context: 'tournament',
+            }
+        });
+        if (!tournament.active) return ({
+            status: SubmitChallengeSpecificStatus.FAIL_TOURNAMENT_INACTIVE,
+            body: {
+                data: tournament.name,
+            }
+        });
+        if (!tournament.visibility) return ({
+            status: SubmitChallengeSpecificStatus.FAIL_TOURNAMENT_HIDDEN,
+            body: {
+                data: tournament ? tournament.name : '(currentTournament)',
+            }
+        });
+        const challenge = await getChallengeOfTournamentByName(challengeName, tournament);
+        if (!challenge) return ({
+            status: OutcomeStatus.FAIL_DNE_DUO,
+            body: {
+                data1: challengeName,
+                context1: 'challenge',
+                data2: tournament.name,
+                context2: 'tournament',
+            },
+        });
+        if (!challenge.visibility) return ({
+            status: SubmitChallengeSpecificStatus.FAIL_CHALLENGE_HIDDEN,
+            body: {
+                data: challenge.name,
+            }
+        });
+        const contestant = await getOrCreateContestant(guildId, contestantId);
+
+        // Fail if contestant already has pending or accepted submission for this challenge
+        const submissions = await getSubmissionsForChallengeFromContestant(challenge, contestant);
+        if (submissions) {
+            // Using for ... of syntax since filter does not support async functions
+            // (Promise<false> is truthy because any Promise is truthy)
+            const nonRejectedSubmissions = new Array<SubmissionDocument>();
+            for (const submission of submissions) {
+                if (await submission.get('status') !== SubmissionStatus.REJECTED) {
+                    nonRejectedSubmissions.push(submission);
+                }
+            }
+            if (nonRejectedSubmissions.length > 0) return ({
+                status: SubmitChallengeSpecificStatus.FAIL_EXISTING_SUBMISSION,
+                body: {
+                    data: challenge.name,
+                }
+                // throw new ChallengeSubmissionError(`Submission rejected due to pending or already accepted submission from this member.`, `Your submission was not sent. Your previous submission to this challenge is either waiting to be approved or was already approved.`);
+            });
         }
+
+        // Create the submission
+        await createSubmission(challenge, contestant, proofLink);
+
+        return ({
+            status: OutcomeStatus.SUCCESS_MONO,
+            body: {
+                data: challenge.name,
+                context: 'challenge',
+            },
+        });
+    } catch (err) {
+        // No expected thrown errors
+    }
+
+    return ({
+        status: OutcomeStatus.FAIL_UNKNOWN,
+        body: {},
+    });
+};
+
+const submitChallengeSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<SubmitChallengeOutcome> => {
+    const guildId = interaction.guildId!;
+
+    const metadataConstraints = new Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>([]);
+
+    const tournament = interaction.options.get('tournament', false);
+    const optionConstraints = new Map<CommandInteractionOption | null, [Constraint<ValueOf<CommandInteractionOption>>]>([
+        [tournament, [
+            // Ensure that the tournament exists, if it was provided
+            {
+                category: OptionValidationErrorStatus.OPTION_DNE,
+                func: async function(option: ValueOf<CommandInteractionOption>): Promise<boolean> {
+                    const tournamentDocument = await getTournamentByName(guildId, option as string);
+                    return tournamentDocument !== null;
+                }
+            },
+        ]],
+    ]);
+
+    let challengeName: string;
+    let proofLink: string;
+    try {
+        challengeName = interaction.options.get('name', true).value! as string;
+        proofLink = interaction.options.get('proof-link', true).value! as string;
+
+        await validateConstraints(interaction, metadataConstraints, optionConstraints);
+    } catch (err) {
+        if (err instanceof OptionValidationError) return ({
+            status: OutcomeStatus.FAIL_VALIDATION,
+            body: {
+                constraint: err.constraint,
+                field: err.field,
+                value: err.value,
+                context: err.message,
+            },
+        });
+
         throw err;
     }
+
+    return await submitChallenge(guildId, challengeName, interaction.member!.user!.id, proofLink, (tournament ? tournament.value as string : undefined));
+};
+
+const submitChallengeSlashCommandDescriptions = new Map<SubmitChallengeStatus, (o: SubmitChallengeOutcome) => SlashCommandDescribedOutcome>([
+    [OutcomeStatus.SUCCESS_MONO, (o: SubmitChallengeOutcome) => ({
+        userMessage: `✅ Submission for **${(o as OutcomeWithMonoBody<string>).body.data}** sent for review!`, ephemeral: true,
+    })],
+    [SubmitChallengeSpecificStatus.FAIL_TOURNAMENT_HIDDEN, (o: SubmitChallengeOutcome) => {
+        if ((o as SubmitChallengeSpecificOutcome).body.data === '(currentTournament)') return ({
+            userMessage: `❌ The current tournament is currently hidden and is not accepting submissions.`, ephemeral: true,
+        });
+        else return ({
+            userMessage: `❌ That tournament is currently hidden and is not accepting submissions.`, ephemeral: true,
+        });
+    }],
+    [SubmitChallengeSpecificStatus.FAIL_TOURNAMENT_INACTIVE, (o: SubmitChallengeOutcome) => ({
+        userMessage: `❌ The tournament **${(o as SubmitChallengeSpecificOutcome).body.data}** is not accepting submissions.`, ephemeral: true,
+    })],
+    [SubmitChallengeSpecificStatus.FAIL_CHALLENGE_HIDDEN, (_: SubmitChallengeOutcome) => ({
+        userMessage: `❌ That challenge is currently hidden and is not accepting submissions.`, ephemeral: true,
+    })],
+    [SubmitChallengeSpecificStatus.FAIL_EXISTING_SUBMISSION, (o: SubmitChallengeOutcome) => ({
+        userMessage: `❌ Your previous submission to **${(o as SubmitChallengeSpecificOutcome).body.data}** is either waiting to be approved or was already approved.`, ephemeral: true,
+    })],
+    [OutcomeStatus.FAIL_DNE_MONO, (o: SubmitChallengeOutcome) => {
+        const oBody = (o as OutcomeWithMonoBody<string>).body;
+        if (oBody.context === 'tournament') return (
+            oBody.data === '(currentTournament)' ? ({
+                userMessage: `❌ The current tournament was not found.`, ephemeral: true
+            }) : ({
+                userMessage: `❌ The tournament **${oBody.data}** was not found.`, ephemeral: true
+            })
+        );
+        else return ({
+            userMessage: `❌ This command failed unexpectedly. **${oBody.data}** does not exist.`, ephemeral: true
+        });
+    }],
+    [OutcomeStatus.FAIL_DNE_DUO, (o: SubmitChallengeOutcome) => {
+        const oBody = (o as OutcomeWithDuoBody<string>).body;
+        if (oBody.context1 === 'challenge' && oBody.context2 === 'tournament') return ({
+            userMessage: `❌ The challenge **${oBody.data1}** was not found in the tournament **${oBody.data2}**.`, ephemeral: true
+        });
+        else return ({
+            userMessage: `❌ This command failed unexpectedly.`, ephemeral: true
+        });
+    }],
+    [OutcomeStatus.FAIL_VALIDATION, (o: SubmitChallengeOutcome) => {
+        const oBody = (o as OptionValidationErrorOutcome<string>).body;
+        if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_DNE) return ({
+            userMessage: `❌ The tournament **${oBody.value}** was not found.`, ephemeral: true
+        });
+        else return ({
+            userMessage: `❌ This command failed unexpectedly due to a validation error.`, ephemeral: true
+        });
+    }],
+]);
+
+const submitChallengeSlashCommandOutcomeDescriber = async (interaction: LimitedCommandInteraction): Promise<SlashCommandDescribedOutcome> => {
+    const outcome = await submitChallengeSlashCommandValidator(interaction);
+    if (submitChallengeSlashCommandDescriptions.has(outcome.status)) return submitChallengeSlashCommandDescriptions.get(outcome.status)!(outcome);
+    // Fallback to trying default descriptions
+    const defaultOutcome = outcome as Outcome<string>;
+    if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
+        return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
+    } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
+};
+
+const judgeSubmissionSlashCommandReplyer = async (interaction: CommandInteraction): Promise<void> => {
+    const describedOutcome = await submitChallengeSlashCommandOutcomeDescriber(limitCommandInteraction(interaction));
+    interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
 };
 
 const SubmitChallengeCommand = new CustomCommand(
@@ -91,21 +248,7 @@ const SubmitChallengeCommand = new CustomCommand(
         .addStringOption(option => option.setName('proof-link').setDescription('Your proof of completing the challenge. Linkless? Send it on this server then Copy Message Link!').setRequired(true))
         .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is part of. Defaults to current tournament.').setRequired(false)) as SlashCommandBuilder,
     async (interaction: CommandInteraction) => {
-        // TODO: Privileges check
-
-
-        try {
-            await submitChallenge(interaction);
-            interaction.reply({ content: `✅ Submission sent for review!`, ephemeral: true });
-        } catch (err) {
-            if (err instanceof UserFacingError) {
-                interaction.reply({ content: `❌ ${err.userMessage}`, ephemeral: true });
-                return;
-            }
-            console.error(`Error in submit-challenge.ts: ${err}`);
-            interaction.reply({ content: `❌ There was an error while sending your submission!`, ephemeral: true });
-            return;
-        }
+        await judgeSubmissionSlashCommandReplyer(interaction);
     }
 );
 

--- a/src/commands/submit-challenge.ts
+++ b/src/commands/submit-challenge.ts
@@ -131,10 +131,10 @@ const submitChallenge = async (guildId: string, challengeName: string, contestan
 const submitChallengeSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<SubmitChallengeOutcome> => {
     const guildId = interaction.guildId!;
 
-    const metadataConstraints = new Map<keyof LimitedCommandInteraction, [Constraint<ValueOf<LimitedCommandInteraction>>]>([]);
+    const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([]);
 
     const tournament = interaction.options.get('tournament', false);
-    const optionConstraints = new Map<CommandInteractionOption | null, [Constraint<ValueOf<CommandInteractionOption>>]>([
+    const optionConstraints = new Map<CommandInteractionOption | null, Constraint<ValueOf<CommandInteractionOption>>[]>([
         [tournament, [
             // Ensure that the tournament exists, if it was provided
             {

--- a/src/commands/submit-challenge.ts
+++ b/src/commands/submit-challenge.ts
@@ -103,8 +103,7 @@ const submitChallenge = async (guildId: string, challengeName: string, contestan
                 status: SubmitChallengeSpecificStatus.FAIL_EXISTING_SUBMISSION,
                 body: {
                     data: challenge.name,
-                }
-                // throw new ChallengeSubmissionError(`Submission rejected due to pending or already accepted submission from this member.`, `Your submission was not sent. Your previous submission to this challenge is either waiting to be approved or was already approved.`);
+                },
             });
         }
 

--- a/src/commands/tournaments.ts
+++ b/src/commands/tournaments.ts
@@ -1,0 +1,217 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction, CommandInteractionOption, GuildMember, PermissionsBitField } from 'discord.js';
+import { CustomCommand } from '../types/customCommand.js';
+import { getTournamentsByGuild } from '../backend/queries/tournamentQueries.js';
+import { TournamentDocument } from '../types/customDocument.js';
+import { OptionValidationError } from '../types/customError.js';
+import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
+import { LimitedCommandInteraction, limitCommandInteraction } from '../types/limitedCommandInteraction.js';
+import { Outcome, OutcomeStatus, OutcomeWithDuoBody, OutcomeWithMonoBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
+import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
+import { ValueOf } from '../types/typelogic.js';
+import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
+import { getJudgeByGuildIdAndMemberId } from '../backend/queries/profileQueries.js';
+
+/**
+ * Status codes specific to this command.
+ */
+enum _TournamentsSpecificStatus {
+
+}
+
+/**
+ * Union of specific and generic status codes.
+ */
+type TournamentsStatus = OutcomeStatus;
+
+
+/**
+ * Union of specific and generic outcomes.
+ */
+type TournamentsOutcome = Outcome<TournamentDocument[]>;
+
+/**
+ * Retrieves all the tournaments for a given guild.
+ * @param guildId The Discord Guild ID.
+ * @param judgeView True iff the output will be shown to a Judge/Admin.
+ * @returns A list of tournaments. The first tournament will be the current tournament, if one exists.
+ * Otherwise, the tournaments are in order of creation (recent-first). If the first tournament in the list isn't
+ * active, then there is no current tournament -- thus no active tournaments either.
+ */
+const tournaments = async (guildId: string, judgeView: boolean): Promise<TournamentsOutcome> => {
+    try {
+        const allTournaments = await getTournamentsByGuild(guildId);
+        if (!allTournaments) return {
+            status: OutcomeStatus.FAIL,
+            body: {},
+        };
+        if (judgeView) {
+            // Place the current tournament first in the list
+            const currentTournament = await getCurrentTournament(guildId);
+            if (!currentTournament) {
+                // No current tournament, but there are tournaments
+                allTournaments.reverse();
+                return {
+                    status: OutcomeStatus.SUCCESS_MONO,
+                    body: {
+                        data: allTournaments,
+                        context: 'tournaments',
+                    },
+                };
+            }
+            const orderedTournaments = allTournaments.filter(tournament => tournament._id !== currentTournament._id);
+            orderedTournaments.push(currentTournament);
+            orderedTournaments.reverse();
+            return {
+                status: OutcomeStatus.SUCCESS_MONO,
+                body: {
+                    data: orderedTournaments,
+                    context: 'tournaments',
+                },
+            };
+        } else {
+            // Place the current tournament first in the list
+            const currentTournament = await getCurrentTournament(guildId);
+            if (!currentTournament) {
+                // No current tournament, but there are tournaments
+                allTournaments.reverse();
+                return {
+                    status: OutcomeStatus.SUCCESS_MONO,
+                    body: {
+                        data: allTournaments.filter(tournament => tournament.visibility),
+                        context: 'tournaments',
+                    },
+                };
+            }
+            // If there is a current tournament, but it's hidden, display a distinct message
+            if (!currentTournament.visibility) {
+                allTournaments.reverse();
+                return {
+                    status: OutcomeStatus.SUCCESS_DUO,
+                    body: {
+                        data1: allTournaments.filter(tournament => tournament.visibility).filter(tournament => tournament._id !== currentTournament._id),
+                        context1: 'tournaments',
+                        data2: [currentTournament],
+                        context2: 'hidden current tournament',
+                    },
+                };
+            }
+            const orderedTournaments = allTournaments.filter(tournament => tournament.visibility).filter(tournament => tournament._id !== currentTournament._id);
+            orderedTournaments.push(currentTournament);
+            orderedTournaments.reverse();
+            return {
+                status: OutcomeStatus.SUCCESS_MONO,
+                body: {
+                    data: orderedTournaments,
+                    context: 'tournaments',
+                },
+            };
+        }
+    } catch (err) {
+        // No expected thrown errors
+    }
+
+    return ({
+        status: OutcomeStatus.FAIL_UNKNOWN,
+        body: {},
+    });
+};
+
+const tournamentsSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<TournamentsOutcome> => {
+    // Validator for this command has the unique responsibility of determining whether to call
+    // business logic method for Judge/Admin or Contestant data
+    const guildId = interaction.guildId!;
+
+    const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([]);
+    const optionConstraints = new Map<CommandInteractionOption | null, Constraint<ValueOf<CommandInteractionOption>>[]>([]);
+
+    const judge = await getJudgeByGuildIdAndMemberId(guildId, (interaction.member as GuildMember).id);
+    const memberIsJudgeOrAdmin = (judge && judge.isActiveJudge) || (interaction.member as GuildMember).permissions.has(PermissionsBitField.Flags.Administrator);
+    // contestantView is True iff user supplies True.
+    // judgeView <=> !contestantView && memberIsJudgeOrAdmin
+    let contestantView: boolean;
+    try {
+        contestantView = interaction.options.get('contestantview', false)?.value as boolean ?? false;
+
+        await validateConstraints(interaction, metadataConstraints, optionConstraints);
+    } catch (err) {
+        if (err instanceof OptionValidationError) return {
+            status: OutcomeStatus.FAIL_VALIDATION,
+            body: {
+                constraint: err.constraint,
+                field: err.field,
+                value: err.value,
+                context: err.message,
+            },
+        };
+
+        throw err;
+    }
+
+    const judgeView = !contestantView && memberIsJudgeOrAdmin;
+    console.log(`DEBUG: contestantView: ${contestantView}, judgeView: ${judgeView}`);
+
+    return await tournaments(guildId, judgeView);
+    
+};
+
+const tournamentsSlashCommandDescriptions = new Map<TournamentsStatus, (o: TournamentsOutcome) => SlashCommandDescribedOutcome>([
+    [OutcomeStatus.SUCCESS_MONO, (o: TournamentsOutcome) => {
+        const oBody = (o as OutcomeWithMonoBody<TournamentDocument[]>).body;
+        let resultString = '';
+        if (oBody.data[0].active) {
+            resultString += `The current tournament is **${oBody.data[0].name}**.`;
+            oBody.data.shift();
+        }
+        const activeTournaments = oBody.data.filter(tournament => tournament.active);
+        const inactiveTournaments = oBody.data.filter(tournament => !tournament.active);
+        if (activeTournaments.length > 0) resultString += `\n\nActive tournaments: ${activeTournaments.map(tournament => `**${tournament.name}**`).join(', ')}`;
+        if (inactiveTournaments.length > 0) resultString += `\n\nInactive tournaments: ${inactiveTournaments.map(tournament => `**${tournament.name}**`).join(', ')}`;
+        
+        return {
+            userMessage: resultString, ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.SUCCESS_DUO, (o: TournamentsOutcome) => {
+        const oBody = (o as OutcomeWithDuoBody<TournamentDocument[]>).body;
+        let resultString = 'The current tournament is *hidden*.';
+        const activeTournaments = oBody.data1.filter(tournament => tournament.active);
+        const inactiveTournaments = oBody.data1.filter(tournament => !tournament.active);
+        if (activeTournaments.length > 0) resultString += `\n\nActive tournaments: ${activeTournaments.map(tournament => `**${tournament.name}**`).join(', ')}`;
+        if (inactiveTournaments.length > 0) resultString += `\n\nInactive tournaments: ${inactiveTournaments.map(tournament => `**${tournament.name}**`).join(', ')}`;
+        
+        return {
+            userMessage: resultString, ephemeral: true,
+        };
+    }],
+    [OutcomeStatus.FAIL, (_: TournamentsOutcome) => ({
+        userMessage: 'There were tournaments found in this server.', ephemeral: true,
+    })],
+]);
+
+const tournamentsSlashCommandOutcomeDescriber = async (interaction: LimitedCommandInteraction): Promise<SlashCommandDescribedOutcome> => {
+    const outcome = await tournamentsSlashCommandValidator(interaction);
+    if (tournamentsSlashCommandDescriptions.has(outcome.status)) return tournamentsSlashCommandDescriptions.get(outcome.status)!(outcome);
+    // Fallback to trying default descriptions
+    const defaultOutcome = outcome as Outcome<string>;
+    if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
+        return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
+    } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
+};
+
+const tournamentsSlashCommandReplyer = async (interaction: CommandInteraction): Promise<void> => {
+    const describedOutcome = await tournamentsSlashCommandOutcomeDescriber(limitCommandInteraction(interaction));
+    interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
+};
+
+const TournamentsCommand = new CustomCommand(
+    new SlashCommandBuilder()
+        .setName('tournaments')
+        .setDescription('Show the tournaments happening in the server.')
+        .addBooleanOption(option => option.setName('contestantview').setDescription('Judges can use True to only show visible tournaments, to see what a contestant sees.').setRequired(false)) as SlashCommandBuilder,
+    async (interaction: CommandInteraction) => {
+        await tournamentsSlashCommandReplyer(interaction);
+    }
+);
+
+export default TournamentsCommand;

--- a/src/commands/tournaments.ts
+++ b/src/commands/tournaments.ts
@@ -24,7 +24,6 @@ enum _TournamentsSpecificStatus {
  */
 type TournamentsStatus = OutcomeStatus;
 
-
 /**
  * Union of specific and generic outcomes.
  */

--- a/src/types/customDocument.ts
+++ b/src/types/customDocument.ts
@@ -4,10 +4,12 @@ import { BeAnObject, IObjectWithTypegooseFunction } from '@typegoose/typegoose/l
 import { Tournament } from '../backend/schemas/tournament.js';
 import { Challenge } from '../backend/schemas/challenge.js';
 import { Contestant } from '../backend/schemas/contestant.js';
-import { Difficulty } from '../backend/schemas/difficulty.js';
+import { Difficulty, DifficultyModel } from '../backend/schemas/difficulty.js';
 import { GuildSettings } from '../backend/schemas/guildsettings.js';
 import { Judge } from '../backend/schemas/judge.js';
 import { Submission } from '../backend/schemas/submission.js';
+import { getChallengesOfTournament } from '../backend/queries/challengeQueries.js';
+import { getDifficultiesOfTournament } from '../backend/queries/tournamentQueries.js';
 
 type GenericDocument<T> = Document<ObjectId, BeAnObject, T> & Omit<T & Required<{ _id: ObjectId; }>, 'typegooseName'> & IObjectWithTypegooseFunction;
 export type TournamentDocument = GenericDocument<Tournament>;
@@ -17,3 +19,69 @@ export type DifficultyDocument = GenericDocument<Difficulty>;
 export type JudgeDocument = GenericDocument<Judge>;
 export type GuildSettingsDocument = GenericDocument<GuildSettings>;
 export type ContestantDocument = GenericDocument<Contestant>;
+
+// These classes replace any with Ref fields (analogous to foreign keys) with their resolved fields.
+// This decouples parts of the codebase from the particulars of the database solution
+// AFAIK, typegoose does not provide an equivalent functionality
+export class ResolvedChallenge {
+    private readonly document: ChallengeDocument;
+
+    public _id!: ObjectId;
+    public name!: string;
+    public description!: string;
+    public difficulty!: DifficultyDocument | null;
+    public game!: string;
+    public visibility!: boolean;
+
+    public constructor(challenge: ChallengeDocument) {
+        this.document = challenge;
+    }
+
+    public async make(): Promise<ResolvedChallenge> {
+        this._id = this.document._id;
+        this.name = this.document.name;
+        this.description = this.document.description;
+        this.difficulty = await DifficultyModel.findById(this.document.difficulty);
+        this.game = this.document.game;
+        this.visibility = this.document.visibility;
+        return this;
+    }
+}
+
+export class ResolvedTournament {
+    private readonly document: TournamentDocument;
+
+    public _id!: ObjectId;
+    public guildId!: string;
+    public name!: string;
+    public photoURI!: string;
+    public active!: boolean;
+    public statusDescription!: string;
+    public visibility!: boolean;
+    public duration!: string;
+    public challenges!: ResolvedChallenge[];
+    public difficulties!: DifficultyDocument[];
+
+    public constructor(tournament: TournamentDocument) {
+        this.document = tournament;
+    }
+
+    public async make(): Promise<ResolvedTournament> {
+        this._id = this.document._id;
+        this.guildId = this.document.guildID;
+        this.name = this.document.name;
+        this.photoURI = this.document.photoURI;
+        this.active = this.document.active;
+        this.statusDescription = this.document.statusDescription;
+        this.visibility = this.document.visibility;
+        this.duration = this.document.duration;
+        const challengeDocuments = await getChallengesOfTournament(this.document);
+        this.challenges = [];
+        for (const challenge of challengeDocuments) {
+            this.challenges.push(await new ResolvedChallenge(challenge).make());
+        }
+        this.difficulties = await getDifficultiesOfTournament(this.document);
+        
+        return this;
+    }
+}

--- a/src/types/customError.ts
+++ b/src/types/customError.ts
@@ -51,6 +51,8 @@ export enum OptionValidationErrorStatus {
     TARGET_USER_BOT = 'TARGET_USER_BOT', // target user is a bot (but should not be)
     NUMBER_BEYOND_RANGE = 'NUMBER_BEYOND_RANGE', // number is outside of the required range
     OPTION_DNE = 'OPTION_DNE', // option's associated data does not exist
+    OPTION_UNDEFAULTABLE = 'OPTION_UNDEFAULTABLE', // optional option not provided and could not be defaulted
+    OPTION_DUPLICATE = 'OPTION_DUPLICATE', // option provides a duplicate of existing data
 }
 
 export class OptionValidationError<T> extends Error {


### PR DESCRIPTION
Closes #29, #55, #56

These three commands all use the new slash command architecture. With the needed minor adjustments done, I think this proves that architecture is sufficient for any use-case and can be officially be considered the standard for new and existing slash commands. Hooray!

#29 suggests this is a temporary tournament list display. The display style here is more than sufficient for our current needs. When I get around to adding embeds, I think I'll essentially give it the same display but in an embed. So, in that sense, the output you see from the command is not really "temporary."

In the interest of getting the new features of this PR and #46 finally shipped to the main branch, I'm setting a deadline of tomorrow for merging a main<--dev PR. I'd like to include feature #57 in that for completeness, but I really don't want to delay any longer. 