### PR TITLE
Add Rendezvous command pattern. Convert /create-challenge to Rendezvous pattern

### DIFF
--- a/src/commands/create-challenge.ts
+++ b/src/commands/create-challenge.ts
@@ -1,17 +1,27 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction, CommandInteractionOption, GuildMember, PermissionsBitField } from 'discord.js';
-import { CustomCommand } from '../types/customCommand.js';
 import { addChallengeToTournament, getDifficultyByEmoji, getTournamentByName } from '../backend/queries/tournamentQueries.js';
 import { ChallengeDocument } from '../types/customDocument.js';
 import { ChallengeModel } from '../backend/schemas/challenge.js';
 import { OptionValidationError, OptionValidationErrorStatus } from '../types/customError.js';
 import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
-import { LimitedCommandInteraction, limitCommandInteraction } from '../types/limitedCommandInteraction.js';
+import { LimitedCommandInteraction } from '../types/limitedCommandInteraction.js';
 import { OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeWithDuoBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
 import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
 import { ValueOf } from '../types/typelogic.js';
 import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
 import { getJudgeByGuildIdAndMemberId } from '../backend/queries/profileQueries.js';
+import { RendezvousSlashCommand } from './slashcommands/architecture/rendezvousCommand.js';
+
+/**
+ * Alias for the first generic type of the command.
+ */
+type T1 = string;
+
+/**
+ * Alias for the second generic type of the command.
+ */
+type T2 = void;
 
 /**
  * Status codes specific to this command.
@@ -29,33 +39,38 @@ type CreateChallengeStatus = OutcomeStatus;
 /**
  * Union of specific and generic outcomes.
  */
-type CreateChallengeOutcome = Outcome<string>;
+type CreateChallengeOutcome = Outcome<T1>;
+
+/**
+ * Parameters for the solver function, as well as the "S" generic type.
+ */
+interface CreateChallengeSolverParams {
+    guildId: string;
+    challengeName: string;
+    game: string;
+    description: string;
+    visible: boolean;
+    tournamentName?: string | undefined;
+    difficulty?: string | undefined;
+}
 
 /**
  * Creates a single Challenge and adds it to a Tournament.
- * @param guildId The Discord Guild ID.
- * @param challengeName The new Challenge name, unique-checked in the specified or current Tournament by validation.
- * @param game The name of the game or other medium.
- * @param description The longer Challenge description.
- * @param visible Whether the Challenge will be visible to contestants.
- * @param tournamentName The name of the Tournament the Challenge is part of. If provided, it should
- * exist (checked by validation); otherwise, defaults to the current Tournament.
- * @param difficulty The emoji representing the Challenge difficulty. If provided, it should exist;
- * (checked by validation) otherwise, defaults to the default difficulty.
+ * @param params The parameters object for the solver function.
  * @returns A CreateChallengeOutcome, in all cases.
  */
-const createChallenge = async (guildId: string, challengeName: string, game: string, description: string, visible: boolean, tournamentName?: string | undefined, difficulty?: string | undefined): Promise<CreateChallengeOutcome> => {
+const createChallengeSolver = async (params: CreateChallengeSolverParams): Promise<CreateChallengeOutcome> => {
     try {
         // Ensure the Tournament and Difficulty exists
-        const tournament = tournamentName ? await getTournamentByName(guildId, tournamentName) : await getCurrentTournament(guildId);
+        const tournament = params.tournamentName ? await getTournamentByName(params.guildId, params.tournamentName) : await getCurrentTournament(params.guildId);
 
         // Create the challenge
         const challenge = await ChallengeModel.create({
-            name: challengeName,
-            description: description,
-            game: game,
-            difficulty: difficulty ? (await getDifficultyByEmoji(tournament!, difficulty))!._id : null,
-            visibility: visible ?? false,
+            name: params.challengeName,
+            description: params.description,
+            game: params.game,
+            difficulty: params.difficulty ? (await getDifficultyByEmoji(tournament!, params.difficulty))!._id : null,
+            visibility: params.visible ?? false,
         });
 
         // Add the challenge to the tournament
@@ -80,7 +95,7 @@ const createChallenge = async (guildId: string, challengeName: string, game: str
     });
 };
 
-const createChallengeSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<CreateChallengeOutcome> => {
+const createChallengeSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<CreateChallengeSolverParams | OptionValidationErrorOutcome<T1>> => {
     const guildId = interaction.guildId!;
 
     const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([
@@ -174,16 +189,23 @@ const createChallengeSlashCommandValidator = async (interaction: LimitedCommandI
         throw err;
     }
 
-    return await createChallenge(guildId, challengeName.value as string, game, description, visible, (tournament ? tournament.value as string : undefined), (difficulty ? difficulty.value as string : undefined));
-    
+    return {
+        guildId: guildId,
+        challengeName: challengeName.value as string,
+        game: game,
+        description: description,
+        visible: visible,
+        tournamentName: tournament ? tournament.value as string : undefined,
+        difficulty: difficulty ? difficulty.value as string : undefined,
+    };
 };
 
 const createChallengeSlashCommandDescriptions = new Map<CreateChallengeStatus, (o: CreateChallengeOutcome) => SlashCommandDescribedOutcome>([
     [OutcomeStatus.SUCCESS_DUO, (o: CreateChallengeOutcome) => ({
-        userMessage: `✅ The challenge **${(o as OutcomeWithDuoBody<string>).body.data1}** was added to tournament **${(o as OutcomeWithDuoBody<string>).body.data2}**.`, ephemeral: true,
+        userMessage: `✅ The challenge **${(o as OutcomeWithDuoBody<T1>).body.data1}** was added to tournament **${(o as OutcomeWithDuoBody<T1>).body.data2}**.`, ephemeral: true,
     })],
     [OutcomeStatus.FAIL_VALIDATION, (o: CreateChallengeOutcome) => {
-        const oBody = (o as OptionValidationErrorOutcome<string>).body;
+        const oBody = (o as OptionValidationErrorOutcome<T1>).body;
         if (oBody.constraint.category === OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS) return ({
             userMessage: `❌ You do not have permission to use this command.`, ephemeral: true,
         });
@@ -202,22 +224,20 @@ const createChallengeSlashCommandDescriptions = new Map<CreateChallengeStatus, (
     }],
 ]);
 
-const createChallengeSlashCommandOutcomeDescriber = async (interaction: LimitedCommandInteraction): Promise<SlashCommandDescribedOutcome> => {
-    const outcome = await createChallengeSlashCommandValidator(interaction);
+const createChallengeSlashCommandOutcomeDescriber = (outcome: CreateChallengeOutcome): SlashCommandDescribedOutcome => {
     if (createChallengeSlashCommandDescriptions.has(outcome.status)) return createChallengeSlashCommandDescriptions.get(outcome.status)!(outcome);
     // Fallback to trying default descriptions
-    const defaultOutcome = outcome as Outcome<string>;
+    const defaultOutcome = outcome as Outcome<T1>;
     if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
         return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
     } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
 };
 
-const createChallengeSlashCommandReplyer = async (interaction: CommandInteraction): Promise<void> => {
-    const describedOutcome = await createChallengeSlashCommandOutcomeDescriber(limitCommandInteraction(interaction));
+const createChallengeSlashCommandReplyer = async (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome): Promise<void> => {
     interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
 };
 
-const CreateChallengeCommand = new CustomCommand(
+const CreateChallengeCommand = new RendezvousSlashCommand<CreateChallengeSolverParams, T1, T2>(
     new SlashCommandBuilder()
         .setName('create-challenge')
         .setDescription('Create a challenge.')
@@ -227,9 +247,10 @@ const CreateChallengeCommand = new CustomCommand(
         .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is part of. Defaults to current tournament.').setRequired(false))
         .addStringOption(option => option.setName('difficulty').setDescription('The emoji representing the challenge level. Defaults to default difficulty.').setRequired(false))
         .addBooleanOption(option => option.setName('visible').setDescription('Whether the challenge is visible to contestants. Defaults true.').setRequired(false)) as SlashCommandBuilder,
-    async (interaction: CommandInteraction) => {
-        await createChallengeSlashCommandReplyer(interaction);
-    }
+    createChallengeSlashCommandReplyer,
+    createChallengeSlashCommandOutcomeDescriber,
+    createChallengeSlashCommandValidator,
+    createChallengeSolver,
 );
 
 export default CreateChallengeCommand;

--- a/src/commands/slashcommands/architecture/rendezvousCommand.ts
+++ b/src/commands/slashcommands/architecture/rendezvousCommand.ts
@@ -4,9 +4,9 @@ import { LimitedCommandInteraction, limitCommandInteraction } from '../../../typ
 
 export interface RendezvousCommand<S, T1, T2 = void> {
     readonly interfacer: SlashCommandBuilder | undefined;
-    readonly replyer: (describedOutcome: SlashCommandDescribedOutcome) => Promise<void>;
+    readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome) => Promise<void>;
     readonly describer: (outcome: Outcome<T1, T2>) => SlashCommandDescribedOutcome; // TODO: Generalize a DescribedOutcome type when/as needed
-    readonly validator: (interaction: LimitedCommandInteraction) => Promise<S> | Outcome<T1, T2>; // Generics for solverParams or (e.g. OptionValidationError)Outcome
+    readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | Outcome<T1, T2>>; // Generics for solverParams or (e.g. OptionValidationError)Outcome
     readonly solver: (solverParams: S) => Promise<Outcome<T1, T2>>;
 
     readonly execute: (interaction: CommandInteraction) => Promise<void>;
@@ -15,9 +15,9 @@ export interface RendezvousCommand<S, T1, T2 = void> {
 export class RendezvousSlashCommand<S, T1, T2 = void> implements RendezvousCommand<S, T1, T2> {
     constructor(
         public readonly interfacer: SlashCommandBuilder,
-        public readonly replyer: (describedOutcome: SlashCommandDescribedOutcome) => Promise<void>,
+        public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome) => Promise<void>,
         public readonly describer: (outcome: Outcome<T1, T2>) => SlashCommandDescribedOutcome,
-        public readonly validator: (interaction: LimitedCommandInteraction) => Promise<S> | OptionValidationErrorOutcome<T1>,
+        public readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>,
         public readonly solver: (solverParams: S) => Promise<Outcome<T1, T2>>
     ) {
         this.interfacer = interfacer;
@@ -43,6 +43,6 @@ export class RendezvousSlashCommand<S, T1, T2 = void> implements RendezvousComma
         // Describer step
         const describedOutcome = this.describer(outcome);
         // Replyer step
-        await this.replyer(describedOutcome);
+        await this.replyer(interaction, describedOutcome);
     }
 }

--- a/src/commands/slashcommands/architecture/rendezvousCommand.ts
+++ b/src/commands/slashcommands/architecture/rendezvousCommand.ts
@@ -1,0 +1,48 @@
+import { CommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { OptionValidationErrorOutcome, Outcome, SlashCommandDescribedOutcome, isValidationErrorOutcome } from '../../../types/outcome.js';
+import { LimitedCommandInteraction, limitCommandInteraction } from '../../../types/limitedCommandInteraction.js';
+
+export interface RendezvousCommand<S, T1, T2 = void> {
+    readonly interfacer: SlashCommandBuilder | undefined;
+    readonly replyer: (describedOutcome: SlashCommandDescribedOutcome) => Promise<void>;
+    readonly describer: (outcome: Outcome<T1, T2>) => SlashCommandDescribedOutcome; // TODO: Generalize a DescribedOutcome type when/as needed
+    readonly validator: (interaction: LimitedCommandInteraction) => Promise<S> | Outcome<T1, T2>; // Generics for solverParams or (e.g. OptionValidationError)Outcome
+    readonly solver: (solverParams: S) => Promise<Outcome<T1, T2>>;
+
+    readonly execute: (interaction: CommandInteraction) => Promise<void>;
+}
+
+export class RendezvousSlashCommand<S, T1, T2 = void> implements RendezvousCommand<S, T1, T2> {
+    constructor(
+        public readonly interfacer: SlashCommandBuilder,
+        public readonly replyer: (describedOutcome: SlashCommandDescribedOutcome) => Promise<void>,
+        public readonly describer: (outcome: Outcome<T1, T2>) => SlashCommandDescribedOutcome,
+        public readonly validator: (interaction: LimitedCommandInteraction) => Promise<S> | OptionValidationErrorOutcome<T1>,
+        public readonly solver: (solverParams: S) => Promise<Outcome<T1, T2>>
+    ) {
+        this.interfacer = interfacer;
+        this.replyer = replyer;
+        this.describer = describer;
+        this.validator = validator;
+        this.solver = solver;
+    }
+
+    public async execute(interaction: CommandInteraction) {
+        // Preprocessing step: remove unneeded properties from the interaction
+        const limitedCommandInteraction = limitCommandInteraction(interaction);
+        // Validator step
+        const solverParamsOrValidationErrorOutcome = await this.validator(limitedCommandInteraction);
+        let outcome: Outcome<T1, T2>; // Minimize code duplication from validation result branching
+        if (isValidationErrorOutcome(solverParamsOrValidationErrorOutcome)) {
+            // Validation failed: skip solver step
+            outcome = solverParamsOrValidationErrorOutcome as OptionValidationErrorOutcome<T1>;
+        } else {
+            // Validation succeeded: proceed to solver step
+            outcome = await this.solver(solverParamsOrValidationErrorOutcome as S);
+        }
+        // Describer step
+        const describedOutcome = this.describer(outcome);
+        // Replyer step
+        await this.replyer(describedOutcome);
+    }
+}

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,14 +1,18 @@
 import { Client, Collection, GatewayIntentBits } from 'discord.js';
 import { CustomCommand } from './customCommand.js';
+import { RendezvousSlashCommand } from '../commands/slashcommands/architecture/rendezvousCommand.js';
 
-export type SlashCommandCollectionPair = {
+// Type alias for RendezvousSlashCommand with unknown generic parameters.
+type RdvsSlashCommandAlias = RendezvousSlashCommand<unknown, unknown, unknown>;
+
+type SlashCommandCollectionPair = {
     name: string;
-    command: CustomCommand;
+    command: CustomCommand | RdvsSlashCommandAlias;
 }
 
 export class TournamentionClient extends Client {
     private static instance: TournamentionClient;
-    private commands: Collection<string, CustomCommand>;
+    private commands: Collection<string, CustomCommand | RdvsSlashCommandAlias>;
 
     private constructor() {
         super({
@@ -26,11 +30,11 @@ export class TournamentionClient extends Client {
         });
     }
 
-    public getCommands(): Collection<string, CustomCommand> {
+    public getCommands(): Collection<string, CustomCommand | RdvsSlashCommandAlias> {
         return this.commands;
     }
 
-    public getCommand(name: string): CustomCommand | undefined {
+    public getCommand(name: string): CustomCommand | RdvsSlashCommandAlias | undefined {
         return this.commands.get(name);
     }
 

--- a/src/types/customCommand.ts
+++ b/src/types/customCommand.ts
@@ -8,3 +8,7 @@ export class CustomCommand {
         this.execute = execute;
     }
 }
+
+export const isCustomCommand = (object: unknown): object is CustomCommand => {
+    return (object as CustomCommand).data !== undefined && (object as CustomCommand).execute !== undefined;
+};

--- a/src/types/outcome.ts
+++ b/src/types/outcome.ts
@@ -53,6 +53,10 @@ export type OptionValidationErrorOutcome<T> = {
     },
 };
 
+export const isValidationErrorOutcome = <T>(x: unknown): x is OptionValidationErrorOutcome<T> => {
+    return (x as OptionValidationErrorOutcome<T>).status === OutcomeStatus.FAIL_VALIDATION;
+};
+
 export type OutcomeWithDuoListBody<T, U> = {
     status: OutcomeStatus.SUCCESS_NO_CHANGE,
     body: {

--- a/src/util/commandHandler.ts
+++ b/src/util/commandHandler.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { pathToFileURL, fileURLToPath } from 'url';
-import { TournamentionClient } from '../types/client';
-import { CustomCommand } from '../types/customCommand';
+import { TournamentionClient } from '../types/client.js';
+import { isCustomCommand } from '../types/customCommand.js';
 
 export const prepareCommands = async (client: TournamentionClient) => {
     const commandsPath = pathToFileURL(path.join(process.cwd(), './src/commands'));
@@ -10,7 +10,12 @@ export const prepareCommands = async (client: TournamentionClient) => {
 
     for (const file of commandFiles) {
         const filePath = pathToFileURL(path.join(fileURLToPath(commandsPath), file)).toString();
-        const command = (await import(filePath)).default as CustomCommand;
-        client.addCommands([{ name: command.data.name, command: command }]);
+        const command = (await import(filePath)).default;
+        if (isCustomCommand(command)) {
+            client.addCommands([{ name: command.data.name, command: command }]);
+        } else {
+            client.addCommands([{ name: command.interfacer.name, command: command }]);
+        }
+        
     }
 };


### PR DESCRIPTION
Progresses #60 and #62

Rendezvous is what I'm calling the newest version of the command architecture I've been exploring for the past couple of weeks. It was getting cumbersome to call it "the new architecture", especially when this branch's focus is substantially updating that architecture to a new iteration. Unfortunately, it's known that naming things is one of the two hard things of computer science, so the trick is finding a descriptive, concise, and ideally catchy name. 

Why "rendezvous"? Some of the main pieces in the architecture are the replyer, describer, and validator. Re-De-V... Rendezvous! Working backwards from this, we can name the yet-nebulously-referred-to business logic method to something starting with S: Solver. The frontend bit comes before the 'R' chronologically so it's tricky to work that in. It could use the 'ou' to form Outsider, but that evokes a slightly different interpretation. I'll think about it, but I'm sticking to Interfacer for now internally -- which I also dislike, both for the obvious reason and because it's the only one out of the 5 that is not a method, and thus isn't a "doer" of anything.

Aside from the surprisingly nice fit on its own, there's minimal naming conflict with other projects. The only thing I could find was the [Rendezvous pattern in distributed computing theory](https://w3.cs.jmu.edu/kirkpams/OpenCSF/Books/csf/html/SynchDesign.html), which is a synchronization mechanism for threads using multiple semaphores, and a few other small repos. I've personally used this pattern before in coursework but not by this name, so it's not a concern for me.

It's nice that it even lines up with the order of work in the architecture currently -- but that does have to change, starting now. Another batch of design documents made obsolete...

First, this PR adds the Rendezvous pattern, with a overarching class interface and a concrete class for slash commands. Creating one is done by supplying the 5 components: Interfacer, Replyer, Describer, Validator, and Solver. Internally, `RendezvousSlashCommand` is hardcoded to call the methods in the following order (typically), reusing data returned from previous steps, rather than having each method call the next as before: Validator, Solver, Describer, and Replyer. I'd show the code here like I did in #46, but I'd basically just be copy-and-pasting it and saying "yep, that's it." It's so incredibly straightforward that there's no need to!

Let's take a moment to reflect on why this change was important and needed. The major advantage is that it allows for substitution of some or all steps by defining different components and using those instead. That brings us even closer to following the SRP. This also opens the door to Dependency Injection techniques, which become much more approachable with this architecture overall. That's really exciting and I plan to leverage that to write substantive testing, once some more work is done to allow for that (e.g. mocking the interaction isn't currently possible without some changes). Though I lament the reordering of operations breaking away from the new name, I think this does a lot for readability and understandability of the architecture, too.

For now, the command handler now has backwards-compatible logic accepting commands represented by both `CustomCommand` and `RendezvousSlashCommand`. As the old commands are converted to Rendezvous, `CustomCommand` will be deprecated and removed in favor of `RendezvousCommand` and its concrete classes for everything. To that end, the command handler logic ideally should expect `RendezvousCommand` instead of `RendezvousSlashCommand` eventually, but until other kinds of commands are implemented the former isn't really used for much -- nor should it be until the needs of the other commands are better understood.

The steps to convert a command from the "new architecture" are as follows:
1. Convert the command definition statement from `CustomCommand` to `RendezvousSlashCommand`
2. Update all the component method headers to match `RendezvousSlashCommand`'s contract. In addition, the Describer method should no longer be `async`.
3. Refactor the component methods to, where relevant, (a) be compatible with the new parameters, (b) remove calls to the next step retrieve that data from the method's arguments instead, and (c) update what data is returned
4. Define the solverParams as needed for the particular Solver. Note that this is known elsewhere as the `S` generic of the `RendezvousSlashCommand`
5. Add type aliases for the types supplied to generics for Outcome. For consistency with the Rendezvous pattern and to avoid "magic values" in various usages across the file, these can be defined at the top of the file and named `T1` and `T2`, where `T2` is sometimes simply `void`. Note that this step doesn't have much to do with Rendezvous directly, but rather is a general improvement to the codebase with a convenient excuse to implement now.