### PR TITLE
Refactor custom outcome definition technique, RendezvousSlashCommand generics. Convert commands to Rendezvous

### DIFF
--- a/src/commands/create-challenge.ts
+++ b/src/commands/create-challenge.ts
@@ -39,7 +39,7 @@ type CreateChallengeStatus = OutcomeStatus;
 /**
  * Union of specific and generic outcomes.
  */
-type CreateChallengeOutcome = Outcome<T1>;
+type CreateChallengeOutcome = Outcome<T1, T2>;
 
 /**
  * Parameters for the solver function, as well as the "S" generic type.
@@ -227,7 +227,7 @@ const createChallengeSlashCommandDescriptions = new Map<CreateChallengeStatus, (
 const createChallengeSlashCommandOutcomeDescriber = (outcome: CreateChallengeOutcome): SlashCommandDescribedOutcome => {
     if (createChallengeSlashCommandDescriptions.has(outcome.status)) return createChallengeSlashCommandDescriptions.get(outcome.status)!(outcome);
     // Fallback to trying default descriptions
-    const defaultOutcome = outcome as Outcome<T1>;
+    const defaultOutcome = outcome as Outcome<string>;
     if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
         return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
     } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
@@ -237,7 +237,7 @@ const createChallengeSlashCommandReplyer = async (interaction: CommandInteractio
     interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
 };
 
-const CreateChallengeCommand = new RendezvousSlashCommand<CreateChallengeSolverParams, T1, T2>(
+const CreateChallengeCommand = new RendezvousSlashCommand<CreateChallengeOutcome, CreateChallengeSolverParams, T1>(
     new SlashCommandBuilder()
         .setName('create-challenge')
         .setDescription('Create a challenge.')

--- a/src/commands/create-challenge.ts
+++ b/src/commands/create-challenge.ts
@@ -1,17 +1,27 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction, CommandInteractionOption, GuildMember, PermissionsBitField } from 'discord.js';
-import { CustomCommand } from '../types/customCommand.js';
 import { addChallengeToTournament, getDifficultyByEmoji, getTournamentByName } from '../backend/queries/tournamentQueries.js';
 import { ChallengeDocument } from '../types/customDocument.js';
 import { ChallengeModel } from '../backend/schemas/challenge.js';
 import { OptionValidationError, OptionValidationErrorStatus } from '../types/customError.js';
 import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
-import { LimitedCommandInteraction, limitCommandInteraction } from '../types/limitedCommandInteraction.js';
+import { LimitedCommandInteraction } from '../types/limitedCommandInteraction.js';
 import { OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeWithDuoBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
 import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
 import { ValueOf } from '../types/typelogic.js';
 import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
 import { getJudgeByGuildIdAndMemberId } from '../backend/queries/profileQueries.js';
+import { RendezvousSlashCommand } from './slashcommands/architecture/rendezvousCommand.js';
+
+/**
+ * Alias for the first generic type of the command.
+ */
+type T1 = string;
+
+/**
+ * Alias for the second generic type of the command.
+ */
+type T2 = void;
 
 /**
  * Status codes specific to this command.
@@ -29,33 +39,38 @@ type CreateChallengeStatus = OutcomeStatus;
 /**
  * Union of specific and generic outcomes.
  */
-type CreateChallengeOutcome = Outcome<string>;
+type CreateChallengeOutcome = Outcome<T1>;
+
+/**
+ * Parameters for the solver function, as well as the "S" generic type.
+ */
+interface CreateChallengeSolverParams {
+    guildId: string;
+    challengeName: string;
+    game: string;
+    description: string;
+    visible: boolean;
+    tournamentName?: string | undefined;
+    difficulty?: string | undefined;
+}
 
 /**
  * Creates a single Challenge and adds it to a Tournament.
- * @param guildId The Discord Guild ID.
- * @param challengeName The new Challenge name, unique-checked in the specified or current Tournament by validation.
- * @param game The name of the game or other medium.
- * @param description The longer Challenge description.
- * @param visible Whether the Challenge will be visible to contestants.
- * @param tournamentName The name of the Tournament the Challenge is part of. If provided, it should
- * exist (checked by validation); otherwise, defaults to the current Tournament.
- * @param difficulty The emoji representing the Challenge difficulty. If provided, it should exist;
- * (checked by validation) otherwise, defaults to the default difficulty.
+ * @param params The parameters object for the solver function.
  * @returns A CreateChallengeOutcome, in all cases.
  */
-const createChallenge = async (guildId: string, challengeName: string, game: string, description: string, visible: boolean, tournamentName?: string | undefined, difficulty?: string | undefined): Promise<CreateChallengeOutcome> => {
+const createChallengeSolver = async (params: CreateChallengeSolverParams): Promise<CreateChallengeOutcome> => {
     try {
         // Ensure the Tournament and Difficulty exists
-        const tournament = tournamentName ? await getTournamentByName(guildId, tournamentName) : await getCurrentTournament(guildId);
+        const tournament = params.tournamentName ? await getTournamentByName(params.guildId, params.tournamentName) : await getCurrentTournament(params.guildId);
 
         // Create the challenge
         const challenge = await ChallengeModel.create({
-            name: challengeName,
-            description: description,
-            game: game,
-            difficulty: difficulty ? (await getDifficultyByEmoji(tournament!, difficulty))!._id : null,
-            visibility: visible ?? false,
+            name: params.challengeName,
+            description: params.description,
+            game: params.game,
+            difficulty: params.difficulty ? (await getDifficultyByEmoji(tournament!, params.difficulty))!._id : null,
+            visibility: params.visible ?? false,
         });
 
         // Add the challenge to the tournament
@@ -80,7 +95,7 @@ const createChallenge = async (guildId: string, challengeName: string, game: str
     });
 };
 
-const createChallengeSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<CreateChallengeOutcome> => {
+const createChallengeSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<CreateChallengeSolverParams | OptionValidationErrorOutcome<T1>> => {
     const guildId = interaction.guildId!;
 
     const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([
@@ -174,16 +189,23 @@ const createChallengeSlashCommandValidator = async (interaction: LimitedCommandI
         throw err;
     }
 
-    return await createChallenge(guildId, challengeName.value as string, game, description, visible, (tournament ? tournament.value as string : undefined), (difficulty ? difficulty.value as string : undefined));
-    
+    return {
+        guildId: guildId,
+        challengeName: challengeName.value as string,
+        game: game,
+        description: description,
+        visible: visible,
+        tournamentName: tournament ? tournament.value as string : undefined,
+        difficulty: difficulty ? difficulty.value as string : undefined,
+    };
 };
 
 const createChallengeSlashCommandDescriptions = new Map<CreateChallengeStatus, (o: CreateChallengeOutcome) => SlashCommandDescribedOutcome>([
     [OutcomeStatus.SUCCESS_DUO, (o: CreateChallengeOutcome) => ({
-        userMessage: `✅ The challenge **${(o as OutcomeWithDuoBody<string>).body.data1}** was added to tournament **${(o as OutcomeWithDuoBody<string>).body.data2}**.`, ephemeral: true,
+        userMessage: `✅ The challenge **${(o as OutcomeWithDuoBody<T1>).body.data1}** was added to tournament **${(o as OutcomeWithDuoBody<T1>).body.data2}**.`, ephemeral: true,
     })],
     [OutcomeStatus.FAIL_VALIDATION, (o: CreateChallengeOutcome) => {
-        const oBody = (o as OptionValidationErrorOutcome<string>).body;
+        const oBody = (o as OptionValidationErrorOutcome<T1>).body;
         if (oBody.constraint.category === OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS) return ({
             userMessage: `❌ You do not have permission to use this command.`, ephemeral: true,
         });
@@ -202,22 +224,20 @@ const createChallengeSlashCommandDescriptions = new Map<CreateChallengeStatus, (
     }],
 ]);
 
-const createChallengeSlashCommandOutcomeDescriber = async (interaction: LimitedCommandInteraction): Promise<SlashCommandDescribedOutcome> => {
-    const outcome = await createChallengeSlashCommandValidator(interaction);
+const createChallengeSlashCommandOutcomeDescriber = (outcome: CreateChallengeOutcome): SlashCommandDescribedOutcome => {
     if (createChallengeSlashCommandDescriptions.has(outcome.status)) return createChallengeSlashCommandDescriptions.get(outcome.status)!(outcome);
     // Fallback to trying default descriptions
-    const defaultOutcome = outcome as Outcome<string>;
+    const defaultOutcome = outcome as Outcome<T1>;
     if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
         return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
     } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
 };
 
-const createChallengeSlashCommandReplyer = async (interaction: CommandInteraction): Promise<void> => {
-    const describedOutcome = await createChallengeSlashCommandOutcomeDescriber(limitCommandInteraction(interaction));
+const createChallengeSlashCommandReplyer = async (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome): Promise<void> => {
     interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
 };
 
-const CreateChallengeCommand = new CustomCommand(
+const CreateChallengeCommand = new RendezvousSlashCommand<CreateChallengeSolverParams, T1, T2>(
     new SlashCommandBuilder()
         .setName('create-challenge')
         .setDescription('Create a challenge.')
@@ -227,9 +247,10 @@ const CreateChallengeCommand = new CustomCommand(
         .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is part of. Defaults to current tournament.').setRequired(false))
         .addStringOption(option => option.setName('difficulty').setDescription('The emoji representing the challenge level. Defaults to default difficulty.').setRequired(false))
         .addBooleanOption(option => option.setName('visible').setDescription('Whether the challenge is visible to contestants. Defaults true.').setRequired(false)) as SlashCommandBuilder,
-    async (interaction: CommandInteraction) => {
-        await createChallengeSlashCommandReplyer(interaction);
-    }
+    createChallengeSlashCommandReplyer,
+    createChallengeSlashCommandOutcomeDescriber,
+    createChallengeSlashCommandValidator,
+    createChallengeSolver,
 );
 
 export default CreateChallengeCommand;

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -62,7 +62,7 @@ type AssignJudgeSuccessSubmissionAppealedOutcome = {
 /**
  * Union of specific and generic outcomes.
  */
-type JudgeSubmissionOutcome = AssignJudgeSuccessSubmissionReviewedOutcome | AssignJudgeSuccessSubmissionAppealedOutcome | Outcome<string, boolean>;
+type JudgeSubmissionOutcome = Outcome<T1, T2, AssignJudgeSuccessSubmissionReviewedOutcome | AssignJudgeSuccessSubmissionAppealedOutcome>;
 
 interface JudgeSubmissionSolverParams {
     guildId: string;

--- a/src/commands/judge-submission.ts
+++ b/src/commands/judge-submission.ts
@@ -1,18 +1,28 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction, CommandInteractionOption, GuildMember, PermissionsBitField } from 'discord.js';
-import { CustomCommand } from '../types/customCommand.js';
 import { OutcomeStatus, Outcome, SlashCommandDescribedOutcome, OutcomeWithDuoListBody, OutcomeWithDuoBody, OutcomeWithMonoBody, OptionValidationErrorOutcome } from '../types/outcome.js';
 import { getChallengeOfTournamentByName } from '../backend/queries/challengeQueries.js';
 import { getContestantByGuildIdAndMemberId, getJudgeByGuildIdAndMemberId } from '../backend/queries/profileQueries.js';
 import { createOrUpdateReviewNoteAndAddTo, getNewestSubmissionForChallengeFromContestant } from '../backend/queries/submissionQueries.js';
 import { OptionValidationError, OptionValidationErrorStatus } from '../types/customError.js';
 import { SubmissionStatus } from '../backend/schemas/submission.js';
-import { LimitedCommandInteraction, limitCommandInteraction } from '../types/limitedCommandInteraction.js';
+import { LimitedCommandInteraction } from '../types/limitedCommandInteraction.js';
 import { ValueOf } from '../types/typelogic.js';
 import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
 import { getTournamentByName } from '../backend/queries/tournamentQueries.js';
 import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
 import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
+import { RendezvousSlashCommand } from './slashcommands/architecture/rendezvousCommand.js';
+
+/**
+ * Alias for the first generic type of the command.
+ */
+type T1 = string;
+
+/**
+ * Alias for the second generic type of the command.
+ */
+type T2 = boolean;
 
 /**
  * Status codes specific to this command.
@@ -54,6 +64,16 @@ type AssignJudgeSuccessSubmissionAppealedOutcome = {
  */
 type JudgeSubmissionOutcome = AssignJudgeSuccessSubmissionReviewedOutcome | AssignJudgeSuccessSubmissionAppealedOutcome | Outcome<string, boolean>;
 
+interface JudgeSubmissionSolverParams {
+    guildId: string;
+    challengeName: string;
+    contestantId: string;
+    judgeId: string;
+    approve: boolean;
+    notes?: string | undefined;
+    tournamentName?: string | undefined;
+}
+
 /**
  * Judges the newest submission for a challenge from a contestant.
  * @param guildId The Discord guild ID.
@@ -65,32 +85,32 @@ type JudgeSubmissionOutcome = AssignJudgeSuccessSubmissionReviewedOutcome | Assi
  * @param tournamentName The name of the Tournament the Challenge is part of. If provided, it should exist; otherwise, defaults to the current Tournament.
  * @returns 
  */
-const judgeSubmission = async (guildId: string, challengeName: string, contestantId: string, judgeId: string, approve: boolean, notes?: string, tournamentName?: string): Promise<JudgeSubmissionOutcome> => {
+const judgeSubmissionSolver = async (params: JudgeSubmissionSolverParams): Promise<JudgeSubmissionOutcome> => {
     try {
         // Ensure the Tournament, Challenge, Contestant, active Judge, and newest Submission exist
-        const tournament = tournamentName ? await getTournamentByName(guildId, tournamentName) : await getCurrentTournament(guildId);
+        const tournament = params.tournamentName ? await getTournamentByName(params.guildId, params.tournamentName) : await getCurrentTournament(params.guildId);
         if (!tournament) return ({
             status: OutcomeStatus.FAIL_DNE_MONO,
             body: {
-                data: tournamentName ? tournamentName : '(currentTournament)',
+                data: params.tournamentName ? params.tournamentName : '(currentTournament)',
                 context: 'tournament',
             },
         });
-        const challenge = await getChallengeOfTournamentByName(challengeName, tournament);
+        const challenge = await getChallengeOfTournamentByName(params.challengeName, tournament);
         if (!challenge) return ({
             status: OutcomeStatus.FAIL_DNE_DUO,
             body: {
-                data1: challengeName,
+                data1: params.challengeName,
                 context1: 'challenge',
                 data2: tournament.name,
                 context2: 'tournament',
             },
         });
-        const contestant = await getContestantByGuildIdAndMemberId(guildId, contestantId);
+        const contestant = await getContestantByGuildIdAndMemberId(params.guildId, params.contestantId);
         if (!contestant) return ({
             status: OutcomeStatus.FAIL_DNE_MONO,
             body: {
-                data: contestantId,
+                data: params.contestantId,
                 context: 'user',
             },
         });
@@ -100,28 +120,28 @@ const judgeSubmission = async (guildId: string, challengeName: string, contestan
             body: {
                 data1: challenge.name,
                 context1: 'challenge',
-                data2: contestantId,
+                data2: params.contestantId,
                 context2: 'user',
             },
         });
-        const judge = await getJudgeByGuildIdAndMemberId(guildId, judgeId);
+        const judge = await getJudgeByGuildIdAndMemberId(params.guildId, params.judgeId);
         if (!judge) return ({
             status: OutcomeStatus.FAIL_DNE_MONO,
             body: {
-                data: judgeId,
+                data: params.judgeId,
                 context: 'judge',
             },
         });
 
         // Create a ReviewNote for the submission
-        const result = (await createOrUpdateReviewNoteAndAddTo(submission, judge, approve ? SubmissionStatus.ACCEPTED : SubmissionStatus.REJECTED, notes))!;
+        const result = (await createOrUpdateReviewNoteAndAddTo(submission, judge, params.approve ? SubmissionStatus.ACCEPTED : SubmissionStatus.REJECTED, params.notes))!;
         if (result.matchedCount === 1 && result.modifiedCount === 0) return ({
             // The submission was reviewed before and is already in the desired status
             status: OutcomeStatus.SUCCESS_NO_CHANGE,
             body: {
-                data1: [contestantId, challengeName],
+                data1: [params.contestantId, params.challengeName],
                 context1: 'user, challenge',
-                data2: [approve],
+                data2: [params.approve],
                 context2: 'approved',
             },
         });
@@ -130,9 +150,9 @@ const judgeSubmission = async (guildId: string, challengeName: string, contestan
             status: JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_APPEALED,
             body: {
                 user: contestant.userID,
-                challengeName: challengeName,
-                previousApproved: !approve,
-                approved: approve,
+                challengeName: params.challengeName,
+                previousApproved: !params.approve,
+                approved: params.approve,
             },
         });
         if (result.matchedCount === 0 && result.upsertedCount === 1) return ({
@@ -140,8 +160,8 @@ const judgeSubmission = async (guildId: string, challengeName: string, contestan
             status: JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_REVIEWED,
             body: {
                 user: contestant.userID,
-                challengeName: challengeName,
-                approved: approve,
+                challengeName: params.challengeName,
+                approved: params.approve,
             },
         });
     } catch (err) {
@@ -154,7 +174,7 @@ const judgeSubmission = async (guildId: string, challengeName: string, contestan
     });
 };
 
-const judgeSubmissionSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<JudgeSubmissionOutcome> => {
+const judgeSubmissionSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<JudgeSubmissionSolverParams | OptionValidationErrorOutcome<T1>> => {
     const guildId = interaction.guildId!;
 
     const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([
@@ -210,7 +230,15 @@ const judgeSubmissionSlashCommandValidator = async (interaction: LimitedCommandI
         throw err;
     }
 
-    return await judgeSubmission(guildId, challengeName, contestant.user!.id, interaction.member!.user!.id, approve, notes, (tournament ? tournament.value as string : undefined));
+    return {
+        guildId: guildId,
+        challengeName: challengeName,
+        contestantId: contestant.user!.id,
+        judgeId: interaction.member!.user!.id,
+        approve: approve,
+        notes: notes,
+        tournamentName: (tournament ? tournament.value as string : undefined),
+    };
 };
 
 const judgeSubmissionSlashCommandDescriptions = new Map<JudgeSubmissionStatus, (o: JudgeSubmissionOutcome) => SlashCommandDescribedOutcome>([
@@ -227,13 +255,13 @@ const judgeSubmissionSlashCommandDescriptions = new Map<JudgeSubmissionStatus, (
         };
     }],
     [OutcomeStatus.SUCCESS_NO_CHANGE, (o: JudgeSubmissionOutcome) => {
-        const oBody = (o as OutcomeWithDuoListBody<string, boolean>).body;
+        const oBody = (o as OutcomeWithDuoListBody<T1, T2>).body;
         return {
             userMessage: `✅ <@${oBody.data1[0]}>'s submission for ${oBody.data1[1]} was already ${oBody.data2[0] ? 'approved' : 'rejected'}.`, ephemeral: true
         };
     }],
     [OutcomeStatus.FAIL_DNE_DUO, (o: JudgeSubmissionOutcome) => {
-        const oBody = (o as OutcomeWithDuoBody<string>).body;
+        const oBody = (o as OutcomeWithDuoBody<T1>).body;
         if (oBody.context1 === 'challenge' && oBody.context2 === 'tournament') return ({
             userMessage: `❌ The challenge **${oBody.data1}** was not found in the tournament **${oBody.data2}**.`, ephemeral: true
         });
@@ -245,7 +273,7 @@ const judgeSubmissionSlashCommandDescriptions = new Map<JudgeSubmissionStatus, (
         });
     }],
     [OutcomeStatus.FAIL_DNE_MONO, (o: JudgeSubmissionOutcome) => {
-        const oBody = (o as OutcomeWithMonoBody<string>).body;
+        const oBody = (o as OutcomeWithMonoBody<T1>).body;
         // Use context to describe what entity doesn't exist.
         if (oBody.context === 'user') return ({
             userMessage: `❌ This failed because <@${oBody.data}> might not be a contestant.`, ephemeral: true
@@ -268,7 +296,7 @@ const judgeSubmissionSlashCommandDescriptions = new Map<JudgeSubmissionStatus, (
         });
     }],
     [OutcomeStatus.FAIL_VALIDATION, (o: JudgeSubmissionOutcome) => {
-        const oBody = (o as OptionValidationErrorOutcome<string>).body;
+        const oBody = (o as OptionValidationErrorOutcome<T1>).body;
         if (oBody.constraint.category === OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS) return ({
             userMessage: `❌ You are not a judge.`, ephemeral: true
         });
@@ -281,8 +309,7 @@ const judgeSubmissionSlashCommandDescriptions = new Map<JudgeSubmissionStatus, (
     }],
 ]);
 
-const judgeSubmissionSlashCommandOutcomeDescriber = async (interaction: LimitedCommandInteraction): Promise<SlashCommandDescribedOutcome> => {
-    const outcome = await judgeSubmissionSlashCommandValidator(interaction);
+const judgeSubmissionSlashCommandOutcomeDescriber = (outcome: JudgeSubmissionOutcome): SlashCommandDescribedOutcome => {
     if (judgeSubmissionSlashCommandDescriptions.has(outcome.status)) return judgeSubmissionSlashCommandDescriptions.get(outcome.status)!(outcome);
     // Fallback to trying default descriptions
     const defaultOutcome = outcome as Outcome<string>;
@@ -291,12 +318,11 @@ const judgeSubmissionSlashCommandOutcomeDescriber = async (interaction: LimitedC
     } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
 };
 
-const judgeSubmissionSlashCommandReplyer = async (interaction: CommandInteraction): Promise<void> => {
-    const describedOutcome = await judgeSubmissionSlashCommandOutcomeDescriber(limitCommandInteraction(interaction));
+const judgeSubmissionSlashCommandReplyer = async (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome): Promise<void> => {
     interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
 };
 
-const JudgeSubmissionCommand = new CustomCommand(
+const JudgeSubmissionCommand = new RendezvousSlashCommand<JudgeSubmissionOutcome, JudgeSubmissionSolverParams, T1>(
     new SlashCommandBuilder()
         .setName('judge-submission')
         .setDescription('Approve or reject the newest submission for a challenge from a contestant.')
@@ -305,9 +331,10 @@ const JudgeSubmissionCommand = new CustomCommand(
         .addBooleanOption(option => option.setName('approve').setDescription('Approve the submission with True, reject it with False.').setRequired(true))
         .addStringOption(option => option.setName('notes').setDescription('Leave a review note or other comment on the submission.').setRequired(false))
         .addStringOption(option => option.setName('tournament').setDescription('The tournament the challenge is part of. Defaults to current tournament.').setRequired(false)) as SlashCommandBuilder,
-    async (interaction: CommandInteraction) => {
-        await judgeSubmissionSlashCommandReplyer(interaction);
-    }
+    judgeSubmissionSlashCommandReplyer,
+    judgeSubmissionSlashCommandOutcomeDescriber,
+    judgeSubmissionSlashCommandValidator,
+    judgeSubmissionSolver,
 );
 
 export default JudgeSubmissionCommand;

--- a/src/commands/slashcommands/architecture/rendezvousCommand.ts
+++ b/src/commands/slashcommands/architecture/rendezvousCommand.ts
@@ -35,10 +35,8 @@ export class RendezvousSlashCommand<O, S, T1> implements RendezvousCommand<O, S,
         let outcome: O; // Minimize code duplication from validation result branching
         if (isValidationErrorOutcome(solverParamsOrValidationErrorOutcome)) {
             // Validation failed: skip solver step
-            // The double cast should (intentionally) error when an incorrect type is provided for O.
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore: Type conversion without overlap (TS2352)
-            outcome = (solverParamsOrValidationErrorOutcome as OptionValidationErrorOutcome<T1>) as O;
+            // The double cast will eventually error when a command provides an incorrect type for O.
+            outcome = solverParamsOrValidationErrorOutcome as OptionValidationErrorOutcome<T1> as unknown as O;
         } else {
             // Validation succeeded: proceed to solver step
             outcome = await this.solver(solverParamsOrValidationErrorOutcome as S);

--- a/src/commands/tournaments.ts
+++ b/src/commands/tournaments.ts
@@ -1,16 +1,26 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction, CommandInteractionOption, GuildMember, PermissionsBitField } from 'discord.js';
-import { CustomCommand } from '../types/customCommand.js';
 import { getTournamentsByGuild } from '../backend/queries/tournamentQueries.js';
 import { ResolvedTournament, TournamentDocument } from '../types/customDocument.js';
 import { OptionValidationError } from '../types/customError.js';
 import { getCurrentTournament } from '../backend/queries/guildSettingsQueries.js';
-import { LimitedCommandInteraction, limitCommandInteraction } from '../types/limitedCommandInteraction.js';
-import { Outcome, OutcomeStatus, OutcomeWithDuoBody, OutcomeWithMonoBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
+import { LimitedCommandInteraction } from '../types/limitedCommandInteraction.js';
+import { OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeWithDuoBody, OutcomeWithMonoBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
 import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
 import { ValueOf } from '../types/typelogic.js';
 import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
 import { getJudgeByGuildIdAndMemberId } from '../backend/queries/profileQueries.js';
+import { RendezvousSlashCommand } from './slashcommands/architecture/rendezvousCommand.js';
+
+/**
+ * Alias for the first generic type of the command.
+ */
+type T1 = ResolvedTournament[];
+
+/**
+ * Alias for the second generic type of the command.
+ */
+type T2 = void;
 
 /**
  * Status codes specific to this command.
@@ -27,7 +37,15 @@ type TournamentsStatus = OutcomeStatus;
 /**
  * Union of specific and generic outcomes.
  */
-type TournamentsOutcome = Outcome<ResolvedTournament[]>;
+type TournamentsOutcome = Outcome<T1, T2>;
+
+/**
+ * Parameters for the solver function, as well as the "S" generic type.
+ */
+interface TournamentsSolverParams {
+    guildId: string;
+    judgeView: boolean;
+}
 
 /**
  * Business logic helper method to convert TournamentDocuments to ResolvedTournaments, thus
@@ -52,16 +70,16 @@ const resolveTournaments = async (tournaments: TournamentDocument[]): Promise<Re
  * Otherwise, the tournaments are in order of creation (recent-first). If the first tournament in the list isn't
  * active, then there is no current tournament -- thus no active tournaments either.
  */
-const tournaments = async (guildId: string, judgeView: boolean): Promise<TournamentsOutcome> => {
+const tournamentsSolver = async (params: TournamentsSolverParams): Promise<TournamentsOutcome> => {
     try {
-        const allTournaments = await getTournamentsByGuild(guildId);
+        const allTournaments = await getTournamentsByGuild(params.guildId);
         if (!allTournaments) return {
             status: OutcomeStatus.FAIL,
             body: {},
         };
-        if (judgeView) {
+        if (params.judgeView) {
             // Place the current tournament first in the list
-            const currentTournament = await getCurrentTournament(guildId);
+            const currentTournament = await getCurrentTournament(params.guildId);
             if (!currentTournament) {
                 // No current tournament, but there are tournaments
                 allTournaments.reverse();
@@ -89,7 +107,7 @@ const tournaments = async (guildId: string, judgeView: boolean): Promise<Tournam
                 body: {},
             });
             // Place the current tournament first in the list
-            const currentTournament = await getCurrentTournament(guildId);
+            const currentTournament = await getCurrentTournament(params.guildId);
             if (!currentTournament) {
                 // No current tournament, but there are tournaments
                 allTournaments.reverse();
@@ -135,7 +153,7 @@ const tournaments = async (guildId: string, judgeView: boolean): Promise<Tournam
     });
 };
 
-const tournamentsSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<TournamentsOutcome> => {
+const tournamentsSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<TournamentsSolverParams | OptionValidationErrorOutcome<T1>> => {
     // Validator for this command has the unique responsibility of determining whether to call
     // business logic method for Judge/Admin or Contestant data
     const guildId = interaction.guildId!;
@@ -168,8 +186,10 @@ const tournamentsSlashCommandValidator = async (interaction: LimitedCommandInter
 
     const judgeView = !contestantView && memberIsJudgeOrAdmin;
 
-    return await tournaments(guildId, judgeView);
-    
+    return {
+        guildId: guildId,
+        judgeView: judgeView,
+    };
 };
 
 /**
@@ -201,7 +221,7 @@ const formatTournamentDetails = (tournament: ResolvedTournament): string => {
 
 const tournamentsSlashCommandDescriptions = new Map<TournamentsStatus, (o: TournamentsOutcome) => SlashCommandDescribedOutcome>([
     [OutcomeStatus.SUCCESS_MONO, (o: TournamentsOutcome) => {
-        const oBody = (o as OutcomeWithMonoBody<ResolvedTournament[]>).body;
+        const oBody = (o as OutcomeWithMonoBody<T1>).body;
         let message = '';
         if (oBody.data[0].active) {
             message += `The current tournament:\n${formatTournamentDetails(oBody.data[0])}`;
@@ -226,7 +246,7 @@ const tournamentsSlashCommandDescriptions = new Map<TournamentsStatus, (o: Tourn
         };
     }],
     [OutcomeStatus.SUCCESS_DUO, (o: TournamentsOutcome) => {
-        const oBody = (o as OutcomeWithDuoBody<ResolvedTournament[]>).body;
+        const oBody = (o as OutcomeWithDuoBody<T1>).body;
         let resultString = 'The current tournament is *hidden*.';
         const activeTournaments = oBody.data1.filter(tournament => tournament.active);
         const inactiveTournaments = oBody.data1.filter(tournament => !tournament.active);
@@ -242,8 +262,7 @@ const tournamentsSlashCommandDescriptions = new Map<TournamentsStatus, (o: Tourn
     })],
 ]);
 
-const tournamentsSlashCommandOutcomeDescriber = async (interaction: LimitedCommandInteraction): Promise<SlashCommandDescribedOutcome> => {
-    const outcome = await tournamentsSlashCommandValidator(interaction);
+const tournamentsSlashCommandOutcomeDescriber = (outcome: TournamentsOutcome): SlashCommandDescribedOutcome => {
     if (tournamentsSlashCommandDescriptions.has(outcome.status)) return tournamentsSlashCommandDescriptions.get(outcome.status)!(outcome);
     // Fallback to trying default descriptions
     const defaultOutcome = outcome as Outcome<string>;
@@ -252,19 +271,19 @@ const tournamentsSlashCommandOutcomeDescriber = async (interaction: LimitedComma
     } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
 };
 
-const tournamentsSlashCommandReplyer = async (interaction: CommandInteraction): Promise<void> => {
-    const describedOutcome = await tournamentsSlashCommandOutcomeDescriber(limitCommandInteraction(interaction));
+const tournamentsSlashCommandReplyer = async (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome): Promise<void> => {
     interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
 };
 
-const TournamentsCommand = new CustomCommand(
+const TournamentsCommand = new RendezvousSlashCommand<TournamentsOutcome, TournamentsSolverParams, T1>(
     new SlashCommandBuilder()
         .setName('tournaments')
         .setDescription('Show the tournaments happening in the server.')
         .addBooleanOption(option => option.setName('contestantview').setDescription('Judges can use True to only show visible tournaments, to see what a contestant sees.').setRequired(false)) as SlashCommandBuilder,
-    async (interaction: CommandInteraction) => {
-        await tournamentsSlashCommandReplyer(interaction);
-    }
+    tournamentsSlashCommandReplyer,
+    tournamentsSlashCommandOutcomeDescriber,
+    tournamentsSlashCommandValidator,
+    tournamentsSolver,
 );
 
 export default TournamentsCommand;

--- a/src/commands/tournaments.ts
+++ b/src/commands/tournaments.ts
@@ -203,7 +203,7 @@ const tournamentsSlashCommandValidator = async (interaction: LimitedCommandInter
  */
 const formatTournamentDetails = (tournament: ResolvedTournament): string => {
     // **My Tournament** (5 challenges
-    let message = `**${tournament.name}** (${tournament.challenges.length} ${tournament.challenges.length !== 0 ? 'challenges' : 'challenge'}`;
+    let message = `**${tournament.name}** (${tournament.challenges.length} ${tournament.challenges.length !== 1 ? 'challenges' : 'challenge'}`;
     // :
     if (tournament.challenges.some(challenge => challenge.difficulty)) message += ':';
     // 2 🔥 1 💀

--- a/src/types/outcome.ts
+++ b/src/types/outcome.ts
@@ -67,4 +67,12 @@ export type OutcomeWithDuoListBody<T, U> = {
     },
 };
 
-export type Outcome<T, U = void> = OutcomeWithEmptyBody | OutcomeWithMonoBody<T> | OutcomeWithDuoBody<T> | OutcomeWithDuoListBody<T, U> | OptionValidationErrorOutcome<T>;
+/**
+ * A placeholder outcome type for when no custom outcomes are needed.
+ */
+type PlaceholderOutcome = {
+    status: OutcomeStatus.FAIL,
+    body: EmptyObject
+}
+
+export type Outcome<T, U = void, V = PlaceholderOutcome> = OutcomeWithEmptyBody | OutcomeWithMonoBody<T> | OutcomeWithDuoBody<T> | OutcomeWithDuoListBody<T, U> | OptionValidationErrorOutcome<T> | V;


### PR DESCRIPTION
Closes #64, #65, #66, #67 by converting the following commands to the RendezvousSlashCommand pattern:
* /assign-judge (was "new architecture" command)
* /judge-submission (was "new architecture" command)
* /submit-challenge (was "new architecture" command)
* /tournaments (was "new architecture" command)

As we know, each command may define some custom Outcomes. Until now, there was never any explicit logical link between Outcome and the custom outcomes. The link was upheld by convention, which was enough temporarily. Well, needing to setup an OO structure for Rendezvous is where this finally became required as there needed to be a common type for a command's outcomes. Now, defining the union of specific and generic outcomes for a command's outcome type is done with the type `Outcome<T1, T2, union | of | custom | outcomes>` instead of `union | of custom | outcomes | Outcome<T1, T2>`. Behind the scenes, Outcome just takes this third optional generic parameter and unions it with the basic Outcome types. This sounds like it's too simple but any file that provides a supposed custom outcome with the wrong layout will cause a compile error. So long as a custom outcome provided this way has the properties `status` and `body`, everything is okay, including any additional properties or whatever form `body` may take, which is loose but ultimately what we want. This might eventually be redone in a classical OO approach where Outcome is a parent type with custom outcomes as children, but this approach is plenty appropriate in JavaScript and TypeScript.

The next change required for the Rendezvous OO structure was to `RendezvousSlashCommand` itself. It needs the custom outcome type in its `execute` method, so this should now be provided in the type parameters. This is a breaking change to existing `RendezvousSlashCommands` but there weren't many yet and this PR fixes all of them.

Here are the complete steps for converting a "new architecture" command to Rendezvous, including changes needed for compatibility with the Outcome changes made in this PR:
1. Convert the command definition statement from CustomCommand to RendezvousSlashCommand
2. Add type parameters to the RendezvousSlashCommand constructor: the existing custom outcome type alias variable (the value of which will be updated later), the particular solver params interface (defined later), and type T1 (defined later)
3. Update all the component method headers to match RendezvousSlashCommand's contract. In addition, the Describer method should no longer be async.
4. Refactor the component methods to, where relevant, (a) be compatible with the new parameters, (b) remove calls to the next step retrieve that data from the method's arguments instead, and (c) update what data is returned
5. Define the solver params interface as needed for the particular Solver. Note that this is known elsewhere as the S generic of the RendezvousSlashCommand
6. Add type aliases for the types supplied to generics for Outcome. For consistency with the Rendezvous pattern and to avoid "magic values" in various usages across the file, these can be defined at the top of the file and named T1 and T2, where T2 is sometimes simply void. Note that this step doesn't have much to do with Rendezvous directly, but rather is a general improvement to the codebase with a convenient excuse to implement now.
7. Update the value of the custom outcome. It should be defined as the alias `Outcome<T1, T2, union | of | custom | outcomes>` instead of `union | of custom | outcomes | Outcome<T1, T2>`.
8. Resolve any other trivial errors, like unused imports.