### PR TITLE
Convert /create-difficulty and /create-tournament to Rendezvous pattern

### DIFF
--- a/src/commands/create-tournament.ts
+++ b/src/commands/create-tournament.ts
@@ -1,10 +1,189 @@
-import { MongoError } from 'mongodb';
 import { SlashCommandBuilder } from '@discordjs/builders';
-import { CommandInteraction } from 'discord.js';
-import { CustomCommand } from '../types/customCommand.js';
-import { TournamentBuilder } from '../backend/queries/tournamentQueries.js';
+import { CommandInteraction, CommandInteractionOption, GuildMember, PermissionsBitField } from 'discord.js';
+import { TournamentBuilder, getTournamentByName } from '../backend/queries/tournamentQueries.js';
+import { RendezvousSlashCommand } from './slashcommands/architecture/rendezvousCommand.js';
+import { OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeWithMonoBody, SlashCommandDescribedOutcome } from '../types/outcome.js';
+import { ResolvedTournament, resolveTournaments } from '../types/customDocument.js';
+import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
+import { LimitedCommandInteraction } from '../types/limitedCommandInteraction.js';
+import { getJudgeByGuildIdAndMemberId } from '../backend/queries/profileQueries.js';
+import { OptionValidationError, OptionValidationErrorStatus } from '../types/customError.js';
+import { ValueOf } from '../types/typelogic.js';
+import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
+import { formatTournamentDetails } from './tournaments.js';
 
-const CreateTournamentCommand = new CustomCommand(
+/**
+ * Alias for the first generic type of the command.
+ */
+type T1 = ResolvedTournament;
+
+/**
+ * Alias for the second generic type of the command.
+ */
+type T2 = void;
+
+/**
+ * Status codes specific to this command.
+ */
+enum _CreateTournamentSpecificStatus {
+
+}
+
+/**
+ * Union of specific and generic status codes.
+ */
+type CreateTournamentStatus = OutcomeStatus;
+
+
+/**
+ * Union of specific and generic outcomes.
+ */
+type CreateTournamentOutcome = Outcome<T1, T2>;
+
+/**
+ * Parameters for the solver function, as well as the "S" generic type.
+ */
+interface CreateTournamentSolverParams {
+    guildId: string;
+    name: string;
+    photoURI: string;
+    visible: boolean;
+    active: boolean;
+    statusDescription: string;
+    duration: string;
+}
+
+/**
+ * Creates a tournament with the given parameters.
+ * @param params The parameters object for the solver function.
+ * @returns A `CreateTournamentOutcome`, in all cases.
+ */
+const createTournamentSolver = async (params: CreateTournamentSolverParams): Promise<CreateTournamentOutcome> => {
+    try {
+        const tournamentBuilder = new TournamentBuilder()
+            .setName(params.name)
+            .setPhotoURI(params.photoURI)
+            .setVisibility(params.visible)
+            .setActive(params.active)
+            .setStatusDescription(params.statusDescription)
+            .setDuration(params.duration);
+        const tournament = await tournamentBuilder.buildForGuild(params.guildId);
+        if (!tournament) return {
+            status: OutcomeStatus.FAIL_UNKNOWN,
+            body: {},
+        };
+
+        return {
+            status: OutcomeStatus.SUCCESS_MONO,
+            body: {
+                data: (await resolveTournaments([tournament]))[0],
+                context: '',
+            },
+        };
+    } catch (err) {
+        // No expected thrown errors
+    }
+
+    return {
+        status: OutcomeStatus.FAIL_UNKNOWN,
+        body: {},
+    };
+};
+
+const createTournamentSlashCommandValidator = async (interaction: LimitedCommandInteraction): Promise<CreateTournamentSolverParams | OptionValidationErrorOutcome<T1>> => {
+    const guildId = interaction.guildId!;
+    const name = interaction.options.get('name', true);
+
+    const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([
+        ['member', [
+            // Ensure that the sender is a Judge or Administrator
+            {
+                category: OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS,
+                func: async function(metadata: ValueOf<LimitedCommandInteraction>): Promise<boolean> {
+                    const judge = await getJudgeByGuildIdAndMemberId(guildId, (metadata as GuildMember).id);
+                    return (judge && judge.isActiveJudge) || (metadata as GuildMember).permissions.has(PermissionsBitField.Flags.Administrator);
+                },
+            },
+        ]],
+    ]);
+    const optionConstraints = new Map<CommandInteractionOption | null, Constraint<ValueOf<CommandInteractionOption>>[]>([
+        [name, [
+            // Ensure that no other Tournament exists with the same name
+            {
+                category: OptionValidationErrorStatus.OPTION_DUPLICATE,
+                func: async function(option: ValueOf<CommandInteractionOption>): Promise<boolean> {
+                    const tournamentDocument = await getTournamentByName(guildId, option as string);
+                    return tournamentDocument === null;
+                },
+            },
+        ]],
+    ]);
+
+    const photoURI = interaction.options.get('photo-uri', false)?.value as string ?? undefined;
+    const visible = interaction.options.get('visible', false)?.value as boolean;
+    const active = interaction.options.get('active', false)?.value as boolean;
+    const statusDescription = interaction.options.get('status-description', false)?.value as string ?? undefined;
+    const duration = interaction.options.get('duration', false)?.value as string ?? undefined;
+
+    try {
+        await validateConstraints(interaction, metadataConstraints, optionConstraints);
+    } catch (err) {
+        if (err instanceof OptionValidationError) return {
+            status: OutcomeStatus.FAIL_VALIDATION,
+            body: {
+                constraint: err.constraint,
+                field: err.field,
+                value: err.value,
+                context: err.message,
+            }
+        };
+
+        throw err;
+    }
+
+    return {
+        guildId,
+        name: name.value as string,
+        photoURI,
+        visible,
+        active,
+        statusDescription,
+        duration,
+    };
+};
+
+const createTournamentSlashCommandDescriptions = new Map<CreateTournamentStatus, (o: CreateTournamentOutcome) => SlashCommandDescribedOutcome>([
+    [OutcomeStatus.SUCCESS_MONO, (o: CreateTournamentOutcome) => ({
+        userMessage: `✅ Tournament created!\n${formatTournamentDetails((o as OutcomeWithMonoBody<T1>).body.data)}`, ephemeral: true
+    })],
+    [OutcomeStatus.FAIL_VALIDATION, (o: CreateTournamentOutcome) => {
+        const oBody = (o as OptionValidationErrorOutcome<T1>).body;
+        if (oBody.constraint.category === OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS) return {
+            userMessage: `❌ You do not have permission to create a tournament.`, ephemeral: true
+        };
+        else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_DUPLICATE) return {
+            userMessage: `❌ A tournament with the name **${oBody.value}** already exists.`, ephemeral: true
+        };
+        else return {
+            userMessage: `❌ This command failed unexpectedly due to a validation error.`, ephemeral: true
+        };
+    }],
+]);
+
+const createTournamentSlashCommandOutcomeDescriber = (outcome: CreateTournamentOutcome): SlashCommandDescribedOutcome => {
+    if (createTournamentSlashCommandDescriptions.has(outcome.status)) return createTournamentSlashCommandDescriptions.get(outcome.status)!(outcome);
+    // Fallback to trying default descriptions
+    const defaultOutcome = outcome as Outcome<string>;
+    if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
+        return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
+    } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
+};
+
+const createTournamentSlashCommandReplyer = async (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome): Promise<void> => {
+    interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
+};
+
+const CreateTournamentCommand = new RendezvousSlashCommand<CreateTournamentOutcome, CreateTournamentSolverParams, T1>(
     new SlashCommandBuilder()
         .setName('create-tournament')
         .setDescription('Create a new tournament from scratch.')
@@ -14,36 +193,10 @@ const CreateTournamentCommand = new CustomCommand(
         .addBooleanOption(option => option.setName('active').setDescription('Whether the tournament is accepting submissions now. Defaults true.').setRequired(false))
         .addStringOption(option => option.setName('status-description').setDescription('An explanation of the tournament\'s current status.').setRequired(false))
         .addStringOption(option => option.setName('duration').setDescription('A simple description of when the tournament takes place.').setRequired(false)) as SlashCommandBuilder,
-    async (interaction: CommandInteraction) => {
-        // TODO: Privileges check
-
-
-        const name = interaction.options.get('name', true).value as string;
-        const photoURI = interaction.options.get('photo-uri', false)?.value as string ?? 'https://imgur.com/MXLHd9R.png';
-        const visible = interaction.options.get('visible', false)?.value as boolean ?? true;
-        const active = interaction.options.get('active', false)?.value as boolean ?? true;
-        const statusDescription = interaction.options.get('status-description', false)?.value as string ?? '';
-        const duration = interaction.options.get('duration', false)?.value as string ?? '';
-
-        const tournament = new TournamentBuilder()
-            .setName(name)
-            .setPhotoURI(photoURI)
-            .setVisibility(visible)
-            .setActive(active)
-            .setStatusDescription(statusDescription)
-            .setDuration(duration);
-        try {
-            await tournament.buildForGuild(interaction.guildId!);
-            interaction.reply({ content: `✅ Tournament created!`, ephemeral: true });
-        } catch (error) {
-            if (error instanceof MongoError && error.code === 11000) {
-                interaction.reply({ content: `❌ A tournament with that name already exists!`, ephemeral: true });
-                return;
-            }
-            console.error(error);
-            interaction.reply({ content: `❌ There was an error while creating the tournament!`, ephemeral: true });
-        }
-    }
+    createTournamentSlashCommandReplyer,
+    createTournamentSlashCommandOutcomeDescriber,
+    createTournamentSlashCommandValidator,
+    createTournamentSolver,
 );
 
 export default CreateTournamentCommand;

--- a/src/types/customError.ts
+++ b/src/types/customError.ts
@@ -53,6 +53,7 @@ export enum OptionValidationErrorStatus {
     OPTION_DNE = 'OPTION_DNE', // option's associated data does not exist
     OPTION_UNDEFAULTABLE = 'OPTION_UNDEFAULTABLE', // optional option not provided and could not be defaulted
     OPTION_DUPLICATE = 'OPTION_DUPLICATE', // option provides a duplicate of existing data
+    OPTION_INVALID = 'OPTION_INVALID', // option provides invalid data. Use sparingly when other status codes are inapplicable
 }
 
 export class OptionValidationError<T> extends Error {


### PR DESCRIPTION
Closes #72 

These are the last existing commands to be converted to the Rendezvous pattern. Both were in the amorphous initial form. They used some interesting design patterns to achieve their behavior, including forethought for supporting batch jobs down the line. Of course, that code is always accessible here, but there wasn't much of a purpose for it right now so this will go away in /create-difficulty in favor of simply calling backend query methods that accomplish the task. /create-tournament's `TournamentBuilder` was preserved, though.

This also adds a new validation error status code `OPTION_INVALID`, meant to be used in very limited fashion where other status codes are inapplicable. For example, this was added for the "is single emoji" constraint in /create-difficulty. What was needed was a string analogue of `NUMBER_BEYOND_RANGE`, so if that need arises in more commands it could become some sort of more specific status code.