### PR TITLE
Add simpler RendezvousSlashCommand subclass, early type support for embeds

### DIFF
--- a/src/commands/challenges.ts
+++ b/src/commands/challenges.ts
@@ -1,8 +1,7 @@
-import { CommandInteraction, CommandInteractionOption, GuildMember, PermissionsBitField, SlashCommandBuilder } from 'discord.js';
-import { defaultSlashCommandDescriptions } from '../types/defaultSlashCommandDescriptions.js';
+import { CommandInteractionOption, GuildMember, PermissionsBitField, SlashCommandBuilder } from 'discord.js';
 import { LimitedCommandInteraction } from '../types/limitedCommandInteraction.js';
 import { OutcomeStatus, Outcome, OptionValidationErrorOutcome, SlashCommandDescribedOutcome } from '../types/outcome.js';
-import { RendezvousSlashCommand } from './slashcommands/architecture/rendezvousCommand.js';
+import { SimpleRendezvousSlashCommand } from './slashcommands/architecture/rendezvousCommand.js';
 import { ValueOf } from '../types/typelogic.js';
 import { Constraint, validateConstraints } from './slashcommands/architecture/validation.js';
 import { getDifficultyByEmoji, getTournamentByName } from '../backend/queries/tournamentQueries.js';
@@ -284,20 +283,7 @@ const challengesSlashCommandDescriptions = new Map<ChallengesStatus, (o: Challen
     })],
 ]);
 
-const challengesSlashCommandOutcomeDescriber = (outcome: ChallengesOutcome): SlashCommandDescribedOutcome => {
-    if (challengesSlashCommandDescriptions.has(outcome.status)) return challengesSlashCommandDescriptions.get(outcome.status)!(outcome);
-    // Fallback to trying default descriptions
-    const defaultOutcome = outcome as Outcome<string>;
-    if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
-        return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
-    } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
-};
-
-const challengesSlashCommandReplyer = async (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome): Promise<void> => {
-    interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
-};
-
-const ChallengesCommand = new RendezvousSlashCommand<ChallengesOutcome, ChallengesSolverParams, T1>(
+const ChallengesCommand = new SimpleRendezvousSlashCommand<ChallengesOutcome, ChallengesSolverParams, T1, ChallengesStatus>(
     new SlashCommandBuilder()
         .setName('challenges')
         .setDescription('Show the challenges posted for a tournament.')
@@ -305,8 +291,7 @@ const ChallengesCommand = new RendezvousSlashCommand<ChallengesOutcome, Challeng
         .addStringOption(option => option.setName('game').setDescription('The name of the game to filter challenges by.').setRequired(false))
         .addStringOption(option => option.setName('difficulty').setDescription('The difficulty emoji to filter challenges by.').setRequired(false))
         .addBooleanOption(option => option.setName('contestantview').setDescription('Judges can use True to only show visible challenges, to see what a contestant sees.').setRequired(false)) as SlashCommandBuilder,
-    challengesSlashCommandReplyer,
-    challengesSlashCommandOutcomeDescriber,
+    challengesSlashCommandDescriptions,
     challengesSlashCommandValidator,
     challengesSolver,
 );

--- a/src/commands/create-challenge.ts
+++ b/src/commands/create-challenge.ts
@@ -223,7 +223,7 @@ const createChallengeSlashCommandDescriptions = new Map<CreateChallengeStatus, (
     }],
 ]);
 
-const CreateChallengeCommand = new SimpleRendezvousSlashCommand<CreateChallengeOutcome, CreateChallengeSolverParams, T1>(
+const CreateChallengeCommand = new SimpleRendezvousSlashCommand<CreateChallengeOutcome, CreateChallengeSolverParams, T1, CreateChallengeStatus>(
     new SlashCommandBuilder()
         .setName('create-challenge')
         .setDescription('Create a challenge.')

--- a/src/commands/slashcommands/architecture/rendezvousCommand.ts
+++ b/src/commands/slashcommands/architecture/rendezvousCommand.ts
@@ -1,24 +1,28 @@
 import { CommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { OptionValidationErrorOutcome, SlashCommandDescribedOutcome, isValidationErrorOutcome } from '../../../types/outcome.js';
+import { DescriptionMap, OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeTypeConstraint, SlashCommandDescribedOutcome, SlashCommandEmbedDescribedOutcome, isEmbedDescribedOutcome, isValidationErrorOutcome } from '../../../types/outcome.js';
 import { LimitedCommandInteraction, limitCommandInteraction } from '../../../types/limitedCommandInteraction.js';
+import { defaultSlashCommandDescriptions } from '../../../types/defaultSlashCommandDescriptions.js';
 
-export interface RendezvousCommand<O, S, T1> {
+export interface RendezvousCommand<O extends OutcomeTypeConstraint, S, T1> {
     readonly interfacer: SlashCommandBuilder | undefined;
     readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome) => Promise<void>;
-    readonly describer: (outcome: O) => SlashCommandDescribedOutcome; // TODO: Generalize a DescribedOutcome type when/as needed
+    readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome; // TODO: Generalize a DescribedOutcome type when/as needed
     readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>; // Generics for solverParams or (e.g. OptionValidationError)Outcome
     readonly solver: (solverParams: S) => Promise<O>;
 
     readonly execute: (interaction: CommandInteraction) => Promise<void>;
 }
 
-export class RendezvousSlashCommand<O, S, T1> implements RendezvousCommand<O, S, T1> {
+export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1> implements RendezvousCommand<O, S, T1> {
+    public readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome;
+
     constructor(
         public readonly interfacer: SlashCommandBuilder,
-        public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome) => Promise<void>,
-        public readonly describer: (outcome: O) => SlashCommandDescribedOutcome,
+        public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => Promise<void>,
+        describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome,
         public readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>,
         public readonly solver: (solverParams: S) => Promise<O>,
+        
     ) {
         this.interfacer = interfacer;
         this.replyer = replyer;
@@ -45,5 +49,31 @@ export class RendezvousSlashCommand<O, S, T1> implements RendezvousCommand<O, S,
         const describedOutcome = this.describer(outcome);
         // Replyer step
         await this.replyer(interaction, describedOutcome);
+    }
+
+    public static async simpleReplyer(interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) {
+        if (isEmbedDescribedOutcome(describedOutcome)) interaction.reply({ embeds: describedOutcome.embeds, components: describedOutcome.components, ephemeral: describedOutcome.ephemeral });
+        else interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
+    }
+}
+
+export class SimpleRendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, CommandStatus = OutcomeStatus> extends RendezvousSlashCommand<O, S, T1> {
+    constructor(
+        interfacer: SlashCommandBuilder,
+        descriptions: DescriptionMap<CommandStatus, O>,
+        validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>,
+        solver: (solverParams: S) => Promise<O>,
+    ) {
+        const describer = (outcome: O) => this.simpleDescriber(outcome, descriptions);
+        super(interfacer, RendezvousSlashCommand.simpleReplyer, describer, validator, solver);
+    }
+
+    private simpleDescriber(outcome: O, descriptions: Map<CommandStatus, (o: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome>) {
+        if (descriptions.has(outcome.status as CommandStatus)) return descriptions.get(outcome.status as CommandStatus)!(outcome);
+        // Fallback to trying default descriptions
+        const defaultOutcome = outcome as unknown as Outcome<string>;
+        if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
+            return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
+        } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
     }
 }

--- a/src/commands/tournaments.ts
+++ b/src/commands/tournaments.ts
@@ -246,7 +246,7 @@ const tournamentsSlashCommandDescriptions = new Map<TournamentsStatus, (o: Tourn
     })],
 ]);
 
-const TournamentsCommand = new SimpleRendezvousSlashCommand<TournamentsOutcome, TournamentsSolverParams, T1>(
+const TournamentsCommand = new SimpleRendezvousSlashCommand<TournamentsOutcome, TournamentsSolverParams, T1, TournamentsStatus>(
     new SlashCommandBuilder()
         .setName('tournaments')
         .setDescription('Show the tournaments happening in the server.')

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,9 +1,10 @@
 import { Client, Collection, GatewayIntentBits } from 'discord.js';
 import { CustomCommand } from './customCommand.js';
 import { RendezvousSlashCommand } from '../commands/slashcommands/architecture/rendezvousCommand.js';
+import { OutcomeTypeConstraint } from './outcome.js';
 
 // Type alias for RendezvousSlashCommand with unknown generic parameters.
-type RdvsSlashCommandAlias = RendezvousSlashCommand<unknown, unknown, unknown>;
+type RdvsSlashCommandAlias = RendezvousSlashCommand<OutcomeTypeConstraint, unknown, unknown>;
 
 type SlashCommandCollectionPair = {
     name: string;

--- a/src/types/outcome.ts
+++ b/src/types/outcome.ts
@@ -1,9 +1,26 @@
+import { Embed, APIActionRowComponent, APIButtonComponent } from 'discord.js';
 import { Constraint } from '../commands/slashcommands/architecture/validation.js';
+
+export type OutcomeTypeConstraint = {
+    status: unknown,
+};
 
 export type SlashCommandDescribedOutcome = {
     userMessage: string,
     ephemeral: boolean,
 };
+
+export type SlashCommandEmbedDescribedOutcome = {
+    embeds: Embed[],
+    components: APIActionRowComponent<APIButtonComponent>[],
+    ephemeral: true,
+};
+
+export const isEmbedDescribedOutcome = (x: unknown): x is SlashCommandEmbedDescribedOutcome => {
+    return (x as SlashCommandEmbedDescribedOutcome).embeds !== undefined;
+};
+
+export type DescriptionMap<S, O> = Map<S, (o: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome>;
 
 export enum OutcomeStatus {
     SUCCESS = 'SUCCESS', // generic success

--- a/src/util/deploy-commands.ts
+++ b/src/util/deploy-commands.ts
@@ -7,6 +7,7 @@ import { REST } from '@discordjs/rest';
 import { Routes } from 'discord-api-types/v9';
 import { RESTPostAPIApplicationCommandsJSONBody } from 'discord.js';
 import { RendezvousCommand } from '../commands/slashcommands/architecture/rendezvousCommand.js';
+import { OutcomeTypeConstraint } from '../types/outcome.js';
 
 const commands = new Array<RESTPostAPIApplicationCommandsJSONBody>();
 const commandsPath = pathToFileURL(path.join(process.cwd(), './src/commands'));
@@ -14,7 +15,7 @@ const commandFiles = fs.readdirSync(commandsPath, { encoding: 'utf8', recursive:
 
 for (const file of commandFiles) {
     const filePath = pathToFileURL(path.join(fileURLToPath(commandsPath), file)).toString();
-    const command = (await import(filePath)).default as RendezvousCommand<unknown, unknown, unknown>;
+    const command = (await import(filePath)).default as RendezvousCommand<OutcomeTypeConstraint, unknown, unknown>;
     commands.push(command.interfacer!.toJSON());
 }
 


### PR DESCRIPTION
There was a lot of easily-recognizable redundant boilerplate code for each `RendezvousSlashCommand` with their replyer and describer methods. These methods had the exact same code in each file (well, almost exact in the case of the describer) and wouldn't be conceivably changed for any reason outside of dependency injection/testing purposes. To simplify the DX of maintaining commands, **all existing commands have been converted** to a new `RendezvousSlashCommand` subclass called `SimpleRendezvousSlashCommand`. 

`SimpleRendezvousSlashCommand`'s usage differs from its parent by (1) not accepting a replyer method, (2) accepting the descriptions map rather than a describer method, and (3) accepting an additional optional generic parameter `CommandStatus`. 
1. The replyer method is now declared statically in `RendezvousSlashCommand`. If, for any reason, you wanted to create a new command that doesn't use `SimpleRendezvousSlashCommand` as its class but don't want to modify the typical behavior of the replyer, you can instead access that method and provide it to the constructor. `SimpleRendezvousSlashCommand` builds this behavior into its constructor.
2. The obvious benefit is reducing repeated code. However, recall that the describer would try to match the status of the outcome against the `OutcomeStatus`es, as well as the particular command statuses, if any custom ones were made. This behavior made adapting the common describer logic into one method slightly more complicated and necessitated (3). Unfortunately, the `simpleDescriber` must use this generic type, as well as the other generic types to work and thus cannot be a static method of a class. This means that if you were to write your own command using `RendezvousSlashCommand` that didn't need to replace the describer, you would actually need to copy over the describer logic yourself. Trying to allow the more convenient behavior is well-intentioned but ultimately makes `RendezvousSlashCommand`'s constructor too complicated for my liking with all the type discrimination or optional parameters needed -- yeah, I tried. Needing to copy over ~8 lines to accomplish this fringe use-case is far preferable to killing readability and type predictability in already tricky part of the codebase.
3. Throw in `FooStatus`, the union of specific status codes and `OutcomeStatus`, you defined in the file as the last generic parameter. Even if you didn't use any custom statuses, this will save you if you do add them later. See (2) above for why this was necessary.

This was introduced now because adding support for embeds as command responses would've required changing a handful of types in every file, so instead the changes were made to the now-centralized replyer and describer methods and these unrelated changes were made instead. Support for embeds is still in flux as I work on getting a command to use them, but this way the changes only need to happen in one place from now on. I won't even go into depth on what I did for embed support until then, but basically for now there are two entirely distinct `DescribedOutcome` types used where `SlashCommandDescribedOutcome` was once used and it's discriminated in the replyer. Importantly, this means commands aren't exclusively embed commands vs. non-embed commands, which is what we'd want.

A lot of these changes look like type wizardry and can't be verified as working at a glance, but from all I've tested they work as normal, including in commands that use custom and generic statuses.