### PR TITLE
Add always-checked option validation constraint support. Fix /challenges's current tournament constraints, RdvsSC parameter definition style

### DIFF
--- a/src/commands/slashcommands/architecture/rendezvousCommand.ts
+++ b/src/commands/slashcommands/architecture/rendezvousCommand.ts
@@ -14,12 +14,11 @@ export interface RendezvousCommand<O extends OutcomeTypeConstraint, S, T1> {
 }
 
 export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1> implements RendezvousCommand<O, S, T1> {
-    public readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome;
 
     constructor(
         public readonly interfacer: SlashCommandBuilder,
         public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => Promise<void>,
-        describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome,
+        public readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome,
         public readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>,
         public readonly solver: (solverParams: S) => Promise<O>,
         


### PR DESCRIPTION
Closes #80, #81. Includes fixes for issues raised in PR #79 review.

While experimenting with what would become `SimpleRendezvousSlashCommand`, I tried allowing other types for the describer parameter. Since it conflicted with the parent class, I moved the definition of describer so that it didn't match the shorthand pattern used by the rest of the parameters. This didn't pan out and I just forgot to change the definition style back to match the rest. This was just a minor style issue and is now fixed.

The validation logic now allows for always-checked constraints in the option constraints. This means conditions can be checked independently of any given option being provided, allowing constraints to be written more intuitively and preventing issues as occurred in #81. For now this functionality is only used in /challenges but other commands that use the old option "hijacking" style should also be refactored.