### PR TITLE
Add message commands support, Approve Submission message command, feature flag config

### DIFF
--- a/src/backend/queries/submissionQueries.ts
+++ b/src/backend/queries/submissionQueries.ts
@@ -4,6 +4,7 @@ import { Challenge } from '../schemas/challenge.js';
 import { Contestant } from '../schemas/contestant.js';
 import { Judge } from '../schemas/judge.js';
 import { Types as MongooseTypes, UpdateWriteOpResult } from 'mongoose';
+import { getCurrentTournament } from './guildSettingsQueries.js';
 
 // CREATE / POST
 export const createSubmission = async (challengeID: Ref<Challenge>, contestantID: Ref<Contestant>, proof: string) => {
@@ -71,6 +72,12 @@ export const getNewestSubmissionForChallengeFromContestant = async (challengeId:
     const newestSubmission = await SubmissionModel.find({ challengeID: challengeId, contestantID: contestantId }).sort({ createdAt: 'descending' }).limit(1).exec();
     if (newestSubmission.length < 1) return null;
     else return newestSubmission[0];
+};
+
+export const getSubmissionInCurrentTournamentFromContestantWithLink = async (guildId: string, contestantId: Ref<Contestant> | string, link: string) => {
+    const currentTournament = await getCurrentTournament(guildId);
+    if (!currentTournament) return null;
+    return SubmissionModel.findOne({ challengeID: { $in: currentTournament.challenges }, contestantID: contestantId, proof: link }).exec();
 };
 
 export const getReviewNoteById = async (id: Ref<ReviewNote> | string) => {

--- a/src/commands/architecture/rendezvousCommand.ts
+++ b/src/commands/architecture/rendezvousCommand.ts
@@ -1,10 +1,10 @@
-import { CommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { CommandInteraction, ContextMenuCommandBuilder, SlashCommandBuilder } from 'discord.js';
 import { DescriptionMap, OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeTypeConstraint, SlashCommandDescribedOutcome, SlashCommandEmbedDescribedOutcome, isEmbedDescribedOutcome, isValidationErrorOutcome } from '../../types/outcome.js';
 import { LimitedCommandInteraction, limitCommandInteraction } from '../../types/limitedCommandInteraction.js';
 import { defaultSlashCommandDescriptions } from '../../types/defaultSlashCommandDescriptions.js';
 
 export interface RendezvousCommand<O extends OutcomeTypeConstraint, S, T1> {
-    readonly interfacer: SlashCommandBuilder | undefined;
+    readonly interfacer: SlashCommandBuilder | ContextMenuCommandBuilder | undefined;
     readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome) => Promise<void>;
     readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome; // TODO: Generalize a DescribedOutcome type when/as needed
     readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>; // Generics for solverParams or (e.g. OptionValidationError)Outcome
@@ -14,7 +14,6 @@ export interface RendezvousCommand<O extends OutcomeTypeConstraint, S, T1> {
 }
 
 export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1> implements RendezvousCommand<O, S, T1> {
-
     constructor(
         public readonly interfacer: SlashCommandBuilder,
         public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => Promise<void>,
@@ -74,5 +73,41 @@ export class SimpleRendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1
         if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
             return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
         } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
+    }
+}
+
+export class RendezvousMessageCommand<O extends OutcomeTypeConstraint, S, T1> implements RendezvousCommand<O, S, T1> {
+    constructor(
+        public readonly interfacer: ContextMenuCommandBuilder,
+        public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => Promise<void>,
+        public readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome,
+        public readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>,
+        public readonly solver: (solverParams: S) => Promise<O>,
+    ) {
+        this.interfacer = interfacer;
+        this.replyer = replyer;
+        this.describer = describer;
+        this.validator = validator;
+        this.solver = solver;
+    }
+
+    public async execute(interaction: CommandInteraction) {
+        // Preprocessing step: remove unneeded properties from the interaction
+        const limitedCommandInteraction = limitCommandInteraction(interaction);
+        // Validator step
+        const solverParamsOrValidationErrorOutcome = await this.validator(limitedCommandInteraction);
+        let outcome: O;
+        if (isValidationErrorOutcome(solverParamsOrValidationErrorOutcome)) {
+            // Validation failed: skip solver step
+            // The double cast will eventually error when a command provides an incorrect type for O.
+            outcome = solverParamsOrValidationErrorOutcome as OptionValidationErrorOutcome<T1> as unknown as O;
+        } else {
+            // Validation succeeded: proceed to solver step
+            outcome = await this.solver(solverParamsOrValidationErrorOutcome as S);
+        }
+        // Describer step
+        const describedOutcome = this.describer(outcome);
+        // Replyer step
+        await this.replyer(interaction, describedOutcome);
     }
 }

--- a/src/commands/messagecommands/approve-submission.ts
+++ b/src/commands/messagecommands/approve-submission.ts
@@ -1,0 +1,284 @@
+import { ApplicationCommandType, CommandInteraction, CommandInteractionOption, ContextMenuCommandBuilder, GuildMember, Message, PermissionsBitField } from 'discord.js';
+import { RendezvousMessageCommand } from '../architecture/rendezvousCommand.js';
+import { OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeWithMonoBody, SlashCommandDescribedOutcome, SlashCommandEmbedDescribedOutcome, isEmbedDescribedOutcome } from '../../types/outcome.js';
+import { getCurrentTournament } from '../../backend/queries/guildSettingsQueries.js';
+import { getSubmissionInCurrentTournamentFromContestantWithLink } from '../../backend/queries/submissionQueries.js';
+import { getContestantByGuildIdAndMemberId, getJudgeByGuildIdAndMemberId } from '../../backend/queries/profileQueries.js';
+import { MakeReviewNoteAndInterpretResultOutcomeStatus, makeReviewNoteAndInterpretResult } from '../slashcommands/judge-submission.js';
+import { getChallengeById } from '../../backend/queries/challengeQueries.js';
+import { ResolvedChallenge } from '../../types/customDocument.js';
+import { OptionValidationErrorStatus, OptionValidationError } from '../../types/customError.js';
+import { LimitedCommandInteraction } from '../../types/limitedCommandInteraction.js';
+import { ValueOf } from '../../types/typelogic.js';
+import { ALWAYS_OPTION_CONSTRAINT, Constraint, validateConstraints } from '../architecture/validation.js';
+import { defaultSlashCommandDescriptions } from '../../types/defaultSlashCommandDescriptions.js';
+
+/**
+ * Alias for the first generic type of the command.
+ */
+type T1 = string;
+
+/**
+ * Alias for the second generic type of the command.
+ */
+type T2 = void;
+
+/**
+ * Status codes specific to this command.
+ */
+enum ApproveSubmissionSpecificStatus {
+    SUCCESS_NO_CHANGE = 'SUCCESS_NO_CHANGE',
+    SUCCESS_SUBMISSION_REVIEWED = 'SUCCESS_SUBMISSION_REVIEWED',
+    SUCCESS_SUBMISSION_APPEALED = 'SUCCESS_SUBMISSION_APPEALED',
+}
+
+/**
+ * Union of specific and generic status codes.
+ */
+type ApproveSubmissionStatus = ApproveSubmissionSpecificStatus | OutcomeStatus;
+
+/**
+ * The outcome format for the specific status code(s).
+ */
+type ApproveSubmissionSuccessOutcome = {
+    status: ApproveSubmissionSpecificStatus.SUCCESS_NO_CHANGE | ApproveSubmissionSpecificStatus.SUCCESS_SUBMISSION_APPEALED | ApproveSubmissionSpecificStatus.SUCCESS_SUBMISSION_REVIEWED;
+    body: {
+        user: string;
+        challenge: ResolvedChallenge;
+    };
+};
+
+/**
+ * Union of specific and generic outcomes.
+ */
+type ApproveSubmissionOutcome = Outcome<T1, T2, ApproveSubmissionSuccessOutcome>;
+
+interface ApproveSubmissionSolverParams {
+    guildId: string;
+    contestantId: string;
+    judgeId: string;
+    messageContents: string;
+}
+
+const approveSubmissionSolver = async (params: ApproveSubmissionSolverParams): Promise<ApproveSubmissionOutcome> => {
+    // Get the current tournament, Judge, and Contestant
+    const tournament = await getCurrentTournament(params.guildId);
+    if (!tournament) return {
+        status: OutcomeStatus.FAIL_DNE_MONO,
+        body: {
+            data: '(currentTournament)',
+            context: 'tournament',
+        },
+    };
+    const judge = await getJudgeByGuildIdAndMemberId(params.guildId, params.judgeId);
+    if (!judge) return {
+        status: OutcomeStatus.FAIL_DNE_MONO,
+        body: {
+            data: '(judge)',
+            context: 'judge',
+        },
+    };
+    const contestant = await getContestantByGuildIdAndMemberId(params.guildId, params.contestantId);
+    if (!contestant) return {
+        status: OutcomeStatus.FAIL_DNE_MONO,
+        body: {
+            data: '(contestant)',
+            context: 'contestant',
+        },
+    };
+
+    // Get the first link in the message
+    const link = params.messageContents.match(/https?:\/\/[^\s]+/)?.[0];
+    if (!link) return {
+        status: OutcomeStatus.FAIL,
+        body: {},
+    };
+    // Find the submissions from the contestant in the current tournament that have this link
+    const submission = await getSubmissionInCurrentTournamentFromContestantWithLink(params.guildId, contestant, link);
+    if (!submission) return {
+        status: OutcomeStatus.FAIL_DNE_MONO,
+        body: {
+            data: '(submission)',
+            context: 'submission',
+        },
+    };
+
+    // Get the challenge details for display purposes
+    const challenge = await getChallengeById(submission.challengeID);
+    if (!challenge) return {
+        status: OutcomeStatus.FAIL_DNE_MONO,
+        body: {
+            data: '(challenge)',
+            context: 'challenge',
+        },
+    };
+
+    // Create a ReviewNote for this submission, reusing logic from /judge-submission
+    const result = await makeReviewNoteAndInterpretResult(submission, judge, true);
+    let status: ApproveSubmissionSpecificStatus;
+    if (result === MakeReviewNoteAndInterpretResultOutcomeStatus.SUCCESS_NO_CHANGE) {
+        status = ApproveSubmissionSpecificStatus.SUCCESS_NO_CHANGE;
+    } else if (result === MakeReviewNoteAndInterpretResultOutcomeStatus.SUCCESS_SUBMISSION_REVIEWED) {
+        status = ApproveSubmissionSpecificStatus.SUCCESS_SUBMISSION_REVIEWED;
+    } else if (result === MakeReviewNoteAndInterpretResultOutcomeStatus.SUCCESS_SUBMISSION_APPEALED) {
+        status = ApproveSubmissionSpecificStatus.SUCCESS_SUBMISSION_APPEALED;
+    } else {
+        return {
+            status: OutcomeStatus.FAIL_UNKNOWN,
+            body: {},
+        };
+    }
+    return {
+        status,
+        body: {
+            user: params.contestantId,
+            challenge: await new ResolvedChallenge(challenge).make(),
+        },
+    };
+};
+
+const approveSubmissionMessageCommandValidator = async (interaction: LimitedCommandInteraction): Promise<ApproveSubmissionSolverParams | OptionValidationErrorOutcome<T1>> => {
+    const guildId = interaction.guildId!;
+
+    const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([
+        ['member', [
+            // Ensure that the sender is a Judge or Administrator
+            {
+                category: OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS,
+                func: async function(metadata: ValueOf<LimitedCommandInteraction>): Promise<boolean> {
+                    const judge = await getJudgeByGuildIdAndMemberId(guildId, (metadata as GuildMember).id);
+                    return (judge && judge.isActiveJudge) || (metadata as GuildMember).permissions.has(PermissionsBitField.Flags.Administrator);
+                },
+            },
+        ]],
+        ['targetMessage', [
+            // Ensure that the bot has permission to read this message's contents
+            {
+                category: OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS,
+                func: async function(metadata: ValueOf<LimitedCommandInteraction>): Promise<boolean> {
+                    try {
+                        await (metadata as Message).fetch();
+                        return true;
+                    } catch (err) {
+                        return false;
+                    }
+                },
+            },
+            // Ensure that the message contains a link or file upload
+            {
+                category: OptionValidationErrorStatus.OPTION_INVALID,
+                func: async function(metadata: ValueOf<LimitedCommandInteraction>): Promise<boolean> {
+                    return (metadata as Message).content.match(/https?:\/\/[^\s]+/)?.[0] !== undefined || (metadata as Message).attachments.size > 0;
+                },
+            },
+        ]],
+    ]);
+
+    const optionConstraints = new Map<CommandInteractionOption | null | ALWAYS_OPTION_CONSTRAINT, Constraint<ValueOf<CommandInteractionOption>>[]>([]);
+
+    let proofLink: string;
+    let contestantId: string;
+
+    try {
+        if (interaction.targetMessage!.attachments.size > 0) proofLink = interaction.targetMessage!.url;
+        // nullish coalescing on .match() to appease linter -- we know from constraints above a link is present in this else case
+        else proofLink = interaction.targetMessage!.content.match(/https?:\/\/[^\s]+/)?.[0] ?? '';
+        contestantId = interaction.targetMessage!.author.id;
+
+        await validateConstraints(interaction, metadataConstraints, optionConstraints);
+    } catch (err) {
+        if (err instanceof OptionValidationError) return {
+            status: OutcomeStatus.FAIL_VALIDATION,
+            body: {
+                constraint: err.constraint,
+                field: err.field,
+                value: err.value,
+                context: err.message,
+            },
+        };
+
+        throw err;
+    }
+
+    return {
+        guildId,
+        judgeId: interaction.member!.user.id,
+        contestantId,
+        messageContents: proofLink,
+    };
+};
+
+const approveSubmissionSlashCommandDescriptions = new Map<ApproveSubmissionStatus, (o: ApproveSubmissionOutcome) => SlashCommandDescribedOutcome>([
+    [ApproveSubmissionSpecificStatus.SUCCESS_SUBMISSION_REVIEWED, (o: ApproveSubmissionOutcome) => {
+        const oBody = (o as ApproveSubmissionSuccessOutcome).body;
+        return {
+            userMessage: `✅ <@${oBody.user}>'s submission for ${oBody.challenge.difficulty?.emoji ? oBody.challenge.difficulty.emoji + ' ' : ''}**${oBody.challenge.name}** approved!`, ephemeral: true
+        };
+    }],
+    [ApproveSubmissionSpecificStatus.SUCCESS_SUBMISSION_APPEALED, (o: ApproveSubmissionOutcome) => {
+        const oBody = (o as ApproveSubmissionSuccessOutcome).body;
+        return {
+            userMessage: `✅ <@${oBody.user}>'s previously rejected submission for ${oBody.challenge.difficulty?.emoji ? oBody.challenge.difficulty.emoji + ' ' : ''}**${oBody.challenge.name}** approved!`, ephemeral: true
+        };
+    }],
+    [ApproveSubmissionSpecificStatus.SUCCESS_NO_CHANGE, (o: ApproveSubmissionOutcome) => {
+        const oBody = (o as ApproveSubmissionSuccessOutcome).body;
+        return {
+            userMessage: `✅ <@${oBody.user}>'s submission for ${oBody.challenge.difficulty?.emoji ? oBody.challenge.difficulty.emoji + ' ' : ''}**${oBody.challenge.name}** was already approved.`, ephemeral: true
+        };
+    }],
+    [OutcomeStatus.FAIL_DNE_MONO, (o: ApproveSubmissionOutcome) => {
+        const oBody = (o as OutcomeWithMonoBody<T1>).body;
+        if (oBody.context === 'tournament') return {
+            userMessage: `❌ There is no current tournament.`, ephemeral: true
+        };
+        else if (oBody.context === 'submission') return {
+            userMessage: `❌ This message does not appear to have an associated submission.`, ephemeral: true
+        };
+        else return {
+            userMessage: `❌ This command failed unexpectedly.`, ephemeral: true
+        };
+    }],
+    [OutcomeStatus.FAIL_VALIDATION, (o: ApproveSubmissionOutcome) => {
+        const oBody = (o as OptionValidationErrorOutcome<T1>).body;
+        if (oBody.constraint.category === OptionValidationErrorStatus.INSUFFICIENT_PERMISSIONS) {
+            if (oBody.field === 'member') return {
+                userMessage: `❌ You do not have permission to use this command.`, ephemeral: true
+            };
+            else return {
+                userMessage: `❌ This command requires the contestant to tag the bot in their message due to Discord's privacy restrictions.`, ephemeral: true
+            };
+        } else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_INVALID) return {
+            userMessage: `❌ This message does not have a link or file upload.`, ephemeral: true
+        };
+        else return {
+            userMessage: `❌ This command failed unexpectedly.`, ephemeral: true
+        };
+    }],
+]);
+
+const approveSubmissionMessageCommandDescriber = (outcome: ApproveSubmissionOutcome): SlashCommandDescribedOutcome => {
+    if (approveSubmissionSlashCommandDescriptions.has(outcome.status as ApproveSubmissionStatus)) return approveSubmissionSlashCommandDescriptions.get(outcome.status as ApproveSubmissionStatus)!(outcome);
+    // Fallback to trying default descriptions
+    const defaultOutcome = outcome as unknown as Outcome<string>;
+    if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
+        return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
+    } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
+};
+
+const approveSubmissionMessageCommandReplyer = async (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => {
+    if (isEmbedDescribedOutcome(describedOutcome)) interaction.reply({ embeds: describedOutcome.embeds, components: describedOutcome.components, ephemeral: describedOutcome.ephemeral });
+    else interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
+};
+
+const ApproveSubmissionCommand = new RendezvousMessageCommand<ApproveSubmissionOutcome, ApproveSubmissionSolverParams, T1>(
+    new ContextMenuCommandBuilder()
+        .setName('Approve Submission')
+        .setType(ApplicationCommandType.Message) as ContextMenuCommandBuilder,
+    approveSubmissionMessageCommandReplyer,
+    approveSubmissionMessageCommandDescriber,
+    approveSubmissionMessageCommandValidator,
+    approveSubmissionSolver,
+);
+
+export default ApproveSubmissionCommand;

--- a/src/commands/slashcommands/judge-submission.ts
+++ b/src/commands/slashcommands/judge-submission.ts
@@ -12,6 +12,7 @@ import { Constraint, validateConstraints } from '../architecture/validation.js';
 import { getTournamentByName } from '../../backend/queries/tournamentQueries.js';
 import { getCurrentTournament } from '../../backend/queries/guildSettingsQueries.js';
 import { SimpleRendezvousSlashCommand } from '../architecture/rendezvousCommand.js';
+import { JudgeDocument, SubmissionDocument } from '../../types/customDocument.js';
 
 /**
  * Alias for the first generic type of the command.
@@ -73,6 +74,28 @@ interface JudgeSubmissionSolverParams {
     tournamentName?: string | undefined;
 }
 
+export enum MakeReviewNoteAndInterpretResultOutcomeStatus {
+    SUCCESS_NO_CHANGE = 'SUCCESS_NO_CHANGE',
+    SUCCESS_SUBMISSION_APPEALED = 'SUCCESS_SUBMISSION_APPEALED',
+    SUCCESS_SUBMISSION_REVIEWED = 'SUCCESS_SUBMISSION_REVIEWED',
+    FAIL = 'FAIL',
+}
+
+export const makeReviewNoteAndInterpretResult = async (submission: SubmissionDocument, judge: JudgeDocument, approve: boolean, notes?: string | undefined): Promise<MakeReviewNoteAndInterpretResultOutcomeStatus> => {
+    const result = (await createOrUpdateReviewNoteAndAddTo(submission, judge, approve ? SubmissionStatus.ACCEPTED : SubmissionStatus.REJECTED, notes))!;
+    // The submission was reviewed before and is already in the desired status
+    if (result.matchedCount === 1 && result.modifiedCount === 0)
+        return MakeReviewNoteAndInterpretResultOutcomeStatus.SUCCESS_NO_CHANGE;
+    // The submission was reviewed before and was modified to the desired status
+    if (result.matchedCount === 1 && result.modifiedCount === 1)
+        return MakeReviewNoteAndInterpretResultOutcomeStatus.SUCCESS_SUBMISSION_APPEALED;
+    // The submission was not reviewed before and was created with the desired status
+    if (result.matchedCount === 0 && result.upsertedCount === 1)
+        return MakeReviewNoteAndInterpretResultOutcomeStatus.SUCCESS_SUBMISSION_REVIEWED;
+
+    return MakeReviewNoteAndInterpretResultOutcomeStatus.FAIL;
+};
+
 /**
  * Judges the newest submission for a challenge from a contestant.
  * @param guildId The Discord guild ID.
@@ -133,9 +156,8 @@ const judgeSubmissionSolver = async (params: JudgeSubmissionSolverParams): Promi
         });
 
         // Create a ReviewNote for the submission
-        const result = (await createOrUpdateReviewNoteAndAddTo(submission, judge, params.approve ? SubmissionStatus.ACCEPTED : SubmissionStatus.REJECTED, params.notes))!;
-        if (result.matchedCount === 1 && result.modifiedCount === 0) return ({
-            // The submission was reviewed before and is already in the desired status
+        const result = await makeReviewNoteAndInterpretResult(submission, judge, params.approve, params.notes);
+        if (result === MakeReviewNoteAndInterpretResultOutcomeStatus.SUCCESS_NO_CHANGE) return {
             status: OutcomeStatus.SUCCESS_NO_CHANGE,
             body: {
                 data1: [params.contestantId, params.challengeName],
@@ -143,9 +165,8 @@ const judgeSubmissionSolver = async (params: JudgeSubmissionSolverParams): Promi
                 data2: [params.approve],
                 context2: 'approved',
             },
-        });
-        if (result.matchedCount === 1 && result.modifiedCount === 1) return ({
-            // The submission was reviewed before and was modified to the desired status
+        };
+        if (result === MakeReviewNoteAndInterpretResultOutcomeStatus.SUCCESS_SUBMISSION_APPEALED) return {
             status: JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_APPEALED,
             body: {
                 user: contestant.userID,
@@ -153,16 +174,15 @@ const judgeSubmissionSolver = async (params: JudgeSubmissionSolverParams): Promi
                 previousApproved: !params.approve,
                 approved: params.approve,
             },
-        });
-        if (result.matchedCount === 0 && result.upsertedCount === 1) return ({
-            // The submission was not reviewed before and was created with the desired status
+        };
+        if (result === MakeReviewNoteAndInterpretResultOutcomeStatus.SUCCESS_SUBMISSION_REVIEWED) return {
             status: JudgeSubmissionSpecificStatus.SUCCESS_SUBMISSION_REVIEWED,
             body: {
                 user: contestant.userID,
                 challengeName: params.challengeName,
                 approved: params.approve,
             },
-        });
+        };        
     } catch (err) {
         // No expected thrown errors
     }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,7 @@
+const config = {
+    'featureFlags': {
+        'privacyMode': false
+    }
+};
+
+export default config;

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,6 +1,7 @@
 import { Client, Collection, GatewayIntentBits } from 'discord.js';
 import { RendezvousSlashCommand } from '../commands/architecture/rendezvousCommand.js';
 import { OutcomeTypeConstraint } from './outcome.js';
+import config from '../config.js';
 
 // Type alias for RendezvousSlashCommand with unknown generic parameters.
 type RdvsSlashCommandAlias = RendezvousSlashCommand<OutcomeTypeConstraint, unknown, unknown>;
@@ -15,10 +16,10 @@ export class TournamentionClient extends Client {
     private commands: Collection<string, RdvsSlashCommandAlias>;
 
     private constructor() {
+        const intents = [GatewayIntentBits.Guilds];
+        if (!config.featureFlags.privacyMode) intents.push(GatewayIntentBits.MessageContent);
         super({
-            intents: [
-                GatewayIntentBits.Guilds,
-            ],
+            intents,
         });
         this.commands = new Collection();
         TournamentionClient.instance = this;

--- a/src/types/limitedCommandInteraction.ts
+++ b/src/types/limitedCommandInteraction.ts
@@ -1,4 +1,4 @@
-import { Snowflake, GuildMember, CommandInteraction, InteractionType, APIInteractionGuildMember } from 'discord.js';
+import { Snowflake, GuildMember, CommandInteraction, InteractionType, APIInteractionGuildMember, Message, MessageContextMenuCommandInteraction } from 'discord.js';
 import { CommandInteractionOptionResolverAlias } from './discordTypeAlias.js';
 
 export type LimitedCommandInteraction = {
@@ -8,11 +8,13 @@ export type LimitedCommandInteraction = {
     member: GuildMember | APIInteractionGuildMember | null;
     options: CommandInteractionOptionResolverAlias;
     type: InteractionType;
+    targetMessage: Message | null;
 };
 
 export const limitCommandInteraction = (interaction: CommandInteraction): LimitedCommandInteraction => {
     const limitedCommandInteraction = {
-        ...interaction
+        ...interaction,
+        targetMessage: interaction.isContextMenuCommand() ? (interaction as MessageContextMenuCommandInteraction).targetMessage : null,
     };
     if (!limitedCommandInteraction.guildId || !limitedCommandInteraction.member) {
         console.error(`Error in limitedCommandInteraction.ts: ${interaction}`);


### PR DESCRIPTION
Closes #30, #85

A new `RendezvousCommand` subclass, `RendezvousMessageCommand`, now enables support for creating Message Context Menu commands. It uses the standard RendezvousCommand interface, which means it doesn't have the simplified DX of `SimpleRendezvousSlashCommand`. This is deemed unnecessary for now since only 5 of these commands are allowed for a bot, and I don't think we'll use more than a couple or so.

With this, the first message context menu command has been created: Approve Submission. It can be used by judges to quickly approve a submission sent in the form of a URL or a file upload by a contestant. I'm happy to say that it works well and is very easy-to-use (with a big asterisk, read on). Since we're trying to squash all the functionality of something like /judge-submission into a command while only being provided the target message's sender and the message's contents, deciding how the application should behave was an interesting challenge. In particular, there are a few notable limitations:
* Only submissions in the current tournament are searched.
* Only submissions from the target message's sender are approved (so a co-op challenge can't have all the members given an approval at once).
* If a contestant uses a submission upload/link as their proof for multiple challenges, the submission that gets approved is not predictable to judges.
  * To my knowledge, it will only be the oldest submission of the oldest challenge using this proof link that gets approved by the command.
  * This behavior could be altered, however I wouldn't consider a contestant using the same proof for multiple challenges/submissions a use-case that should be supported or encouraged.
* Judges will only see what challenge the upload/link was submitted for after using the command. If they are not careful in reviewing the feedback message, the contestant could deceive the judges and get a different challenge approved instead.

Furthermore, the biggest limitation of Approve Submission is that, since reading a message's contents requires either a privileged intent or for the message to tag the bot, this command is much less useful in a public deployment context. This is why I've made the decision to split the bot's functionality in such cases between a toggleable "privacy mode". This is done through a feature flag in a new config file. For a potential public deployment of the bot, privacy mode would be enabled, meaning that this command is only usable on submission messages that mention the bot. For the deployment on our private server, I have created a separate bot application that disables privacy mode, thus allowing it to be used on any message. Minimizing how much users need to change their workflow is going to be huge for adoption in that case, so there was really no alternative. In the future, approval for the intent can be sought, but this is granted by Discord staff in order to be used on >100 servers. You can read more about all of this in #85.

Lastly, I'll reiterate that the config file, which for now only contains the "privacy mode" feature flag, is a .js file because our tech stack [apparently doesn't play nice with imported JSON files](https://github.com/microsoft/TypeScript/issues/51783). 