### PR TITLE
Add pagination to /challenges

### DIFF
--- a/src/backend/queries/challengeQueries.ts
+++ b/src/backend/queries/challengeQueries.ts
@@ -36,7 +36,7 @@ export const getChallengesOfTournamentPaged = async (tournamentId: Ref<Tournamen
     const query = ChallengeModel
         .find()
         .where('_id').in(tournament!.challenges)
-        .sort({ name: 1, difficulty: 1, _id: 1});
+        .sort({ game: 1, difficulty: 1, name: 1, _id: 1});
     const countQuery = query.clone().countDocuments();
     const totalPages = Math.ceil(await (countQuery.countDocuments().exec()) / pageLimit);
     const challenges = await query.skip(page * pageLimit).limit(pageLimit).exec();
@@ -55,7 +55,7 @@ export const getChallengesOfTournamentByGamePaged = async (tournamentId: Ref<Tou
         .find()
         .where('_id').in(tournament!.challenges)
         .where('game').equals(game)
-        .sort({ name: 1, difficulty: 1, _id: 1});
+        .sort({ game: 1, difficulty: 1, name: 1, _id: 1});
     const countQuery = query.clone().countDocuments();
     const totalPages = Math.ceil(await (countQuery.countDocuments().exec()) / pageLimit);
     const challenges = await query.skip(page * pageLimit).limit(pageLimit).exec();

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -112,10 +112,12 @@ export const getTournamentByName = async (guildID: string, name: string): Promis
     return TournamentModel.findOne({ guildID: guildID, name: name });
 };
 
+const explicitSupportedEmojis = ['2️⃣', '3️⃣', '4️⃣', '5️⃣'];
+
 export const isSingleEmoji = (emoji: string): boolean => {
     const emojiRegex = /\p{Emoji_Presentation}/ug;
     const matches = emoji.match(emojiRegex);
-    return matches !== null && matches.length === 1;
+    return (matches !== null && matches.length === 1) || explicitSupportedEmojis.includes(emoji);
 };
 
 export const getDifficultyByID = async (id: Ref<Difficulty> | string): Promise<DifficultyDocument | null> => {

--- a/src/buttons/architecture/CustomButton.ts
+++ b/src/buttons/architecture/CustomButton.ts
@@ -1,0 +1,37 @@
+import { APIButtonComponentWithCustomId, ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
+
+
+class CustomButton {
+    private component: APIButtonComponentWithCustomId;
+
+    constructor(
+        private builder: ButtonBuilder,
+        public execute: (interaction: ButtonInteraction) => Promise<void>,
+    ) {
+        this.builder = builder;
+        this.component = builder.toJSON() as APIButtonComponentWithCustomId;
+        this.execute = execute;
+    }
+
+    public getBuilder(): ButtonBuilder {
+        return this.builder;
+    }
+
+    public getCustomId(): string {
+        return this.component.custom_id;
+    }
+
+    public getLabel(): string | undefined {
+        return this.component.label;
+    }
+
+    public getStyle(): ButtonStyle {
+        return this.component.style;
+    }
+
+    public isEnabled(): boolean | undefined {
+        return !this.component.disabled;
+    }
+}
+
+export default CustomButton;

--- a/src/buttons/architecture/CustomButton.ts
+++ b/src/buttons/architecture/CustomButton.ts
@@ -1,6 +1,5 @@
 import { APIButtonComponentWithCustomId, ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
 
-
 class CustomButton {
     private component: APIButtonComponentWithCustomId;
 

--- a/src/buttons/first.ts
+++ b/src/buttons/first.ts
@@ -1,0 +1,33 @@
+import { ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
+import CustomButton from './architecture/CustomButton.js';
+import { TournamentionClient } from '../types/client.js';
+import { isEmbedDescribedOutcome } from '../types/outcome.js';
+import { CachedChallengesInteraction } from '../types/cachedInteractions.js';
+
+const firstButton = new CustomButton(
+    new ButtonBuilder()
+        .setCustomId('first')
+        .setLabel('⏪ First')
+        .setStyle(ButtonStyle.Primary),
+    async (interaction: ButtonInteraction) => {
+        // Find cached data for this original interaction
+        const client = await TournamentionClient.getInstance();
+        const cached = client.getCachedInteraction(interaction.message.interaction!.id) as CachedChallengesInteraction;
+        if (!cached) {
+            await interaction.reply({ content: 'This interaction has expired.', ephemeral: true });
+            return;
+        }
+        // Re-run the solver to get the new page
+        const describedOutcome = await cached.solveAgainAndDescribe(0);
+        // Update the original interaction
+        if (isEmbedDescribedOutcome(describedOutcome)) {
+            interaction.update({ embeds: describedOutcome.embeds, components: describedOutcome.components });
+        } else {
+            interaction.update({ content: describedOutcome.userMessage });
+        }
+        // Update the cached interaction with the new page number
+        cached.setPage(0);
+    }
+);
+
+export default firstButton;

--- a/src/buttons/last.ts
+++ b/src/buttons/last.ts
@@ -1,0 +1,33 @@
+import { ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
+import CustomButton from './architecture/CustomButton.js';
+import { TournamentionClient } from '../types/client.js';
+import { isEmbedDescribedOutcome } from '../types/outcome.js';
+import { CachedChallengesInteraction } from '../types/cachedInteractions.js';
+
+const lastButton = new CustomButton(
+    new ButtonBuilder()
+        .setCustomId('last')
+        .setLabel('Last ⏩')
+        .setStyle(ButtonStyle.Primary),
+    async (interaction: ButtonInteraction) => {
+        // Find cached data for this original interaction
+        const client = await TournamentionClient.getInstance();
+        const cached = client.getCachedInteraction(interaction.message.interaction!.id) as CachedChallengesInteraction;
+        if (!cached) {
+            await interaction.reply({ content: 'This interaction has expired!', ephemeral: true });
+            return;
+        }
+        // Re-run the solver to get the new page
+        const describedOutcome = await cached.solveAgainAndDescribe(cached.totalPages - 1);
+        // Update the original interaction
+        if (isEmbedDescribedOutcome(describedOutcome)) {
+            interaction.update({ embeds: describedOutcome.embeds, components: describedOutcome.components });
+        } else {
+            interaction.update({ content: describedOutcome.userMessage });
+        }
+        // Update the cached interaction with the new page number
+        cached.setPage(cached.totalPages - 1);
+    }
+);
+
+export default lastButton;

--- a/src/buttons/next.ts
+++ b/src/buttons/next.ts
@@ -1,0 +1,34 @@
+import { ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
+import CustomButton from './architecture/CustomButton.js';
+import { CachedChallengesInteraction } from '../types/cachedInteractions.js';
+import { TournamentionClient } from '../types/client.js';
+import { isEmbedDescribedOutcome } from '../types/outcome.js';
+
+const nextButton = new CustomButton(
+    new ButtonBuilder()
+        .setCustomId('next')
+        .setLabel('Next ▶️')
+        .setStyle(ButtonStyle.Primary),
+    async (interaction: ButtonInteraction) => {
+        // Find cached data for this original interaction
+        const client = await TournamentionClient.getInstance();
+        const cached = client.getCachedInteraction(interaction.message.interaction!.id) as CachedChallengesInteraction;
+        if (!cached) {
+            await interaction.reply({ content: 'This interaction has expired!', ephemeral: true });
+            return;
+        }
+        const newPage = Math.min(cached.solverParams.page + 1, cached.totalPages - 1);
+        // Re-run the solver to get the new page
+        const describedOutcome = await cached.solveAgainAndDescribe(newPage);
+        // Update the original interaction
+        if (isEmbedDescribedOutcome(describedOutcome)) {
+            interaction.update({ embeds: describedOutcome.embeds, components: describedOutcome.components });
+        } else {
+            interaction.update({ content: describedOutcome.userMessage });
+        }
+        // Update the cached interaction with the new page number
+        cached.setPage(newPage);
+    }
+);
+
+export default nextButton;

--- a/src/buttons/previous.ts
+++ b/src/buttons/previous.ts
@@ -1,0 +1,34 @@
+import { ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
+import CustomButton from './architecture/CustomButton.js';
+import { CachedChallengesInteraction } from '../types/cachedInteractions.js';
+import { TournamentionClient } from '../types/client.js';
+import { isEmbedDescribedOutcome } from '../types/outcome.js';
+
+const previousButton = new CustomButton(
+    new ButtonBuilder()
+        .setCustomId('previous')
+        .setLabel('◀️ Previous')
+        .setStyle(ButtonStyle.Primary),
+    async (interaction: ButtonInteraction) => {
+        // Find cached data for this original interaction
+        const client = await TournamentionClient.getInstance();
+        const cached = client.getCachedInteraction(interaction.message.interaction!.id) as CachedChallengesInteraction;
+        if (!cached) {
+            await interaction.reply({ content: 'This interaction has expired!', ephemeral: true });
+            return;
+        }
+        const newPage = Math.max(cached.solverParams.page - 1, 0);
+        // Re-run the solver to get the new page
+        const describedOutcome = await cached.solveAgainAndDescribe(newPage);
+        // Update the original interaction
+        if (isEmbedDescribedOutcome(describedOutcome)) {
+            interaction.update({ embeds: describedOutcome.embeds, components: describedOutcome.components });
+        } else {
+            interaction.update({ content: describedOutcome.userMessage });
+        }
+        // Update the cached interaction with the new page number
+        cached.setPage(newPage);
+    }
+);
+
+export default previousButton;

--- a/src/commands/slashcommands/challenges.ts
+++ b/src/commands/slashcommands/challenges.ts
@@ -1,4 +1,4 @@
-import { CommandInteractionOption, EmbedBuilder, GuildMember, PermissionsBitField, SlashCommandBuilder } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, CommandInteractionOption, EmbedBuilder, GuildMember, PermissionsBitField, SlashCommandBuilder } from 'discord.js';
 import { LimitedCommandInteraction } from '../../types/limitedCommandInteraction.js';
 import { OutcomeStatus, Outcome, OptionValidationErrorOutcome, SlashCommandDescribedOutcome, SlashCommandEmbedDescribedOutcome, PaginatedOutcome } from '../../types/outcome.js';
 import { SimpleRendezvousSlashCommand } from '../architecture/rendezvousCommand.js';
@@ -12,6 +12,10 @@ import { getJudgeByGuildIdAndMemberId } from '../../backend/queries/profileQueri
 import { ChallengeDocument, ResolvedChallenge, ResolvedTournament } from '../../types/customDocument.js';
 import { CachedChallengesInteraction } from '../../types/cachedInteractions.js';
 import { TournamentionClient } from '../../types/client.js';
+import firstButton from '../../buttons/first.js';
+import lastButton from '../../buttons/last.js';
+import nextButton from '../../buttons/next.js';
+import previousButton from '../../buttons/previous.js';
 
 /**
  * Alias for the first generic type of the command.
@@ -34,7 +38,7 @@ enum ChallengesSpecificStatus {
 /**
  * Union of specific and generic status codes.
  */
-type ChallengesStatus = ChallengesSpecificStatus | OutcomeStatus;
+export type ChallengesStatus = ChallengesSpecificStatus | OutcomeStatus;
 
 /**
  * The outcome format for the specific status code(s).
@@ -67,7 +71,7 @@ type ChallengesOutcome = Outcome<T1, T2, ChallengesSpecificOutcome>;
 /**
  * Parameters for the solver function, as well as the "S" generic type.
  */
-interface ChallengesSolverParams {
+export interface ChallengesSolverParams {
     guildId: string;
     judgeView: boolean;
     tournament?: string | undefined;
@@ -76,7 +80,7 @@ interface ChallengesSolverParams {
     page: number;
 }
 
-const challengesSolver = async (params: ChallengesSolverParams): Promise<ChallengesOutcome> => {
+export const challengesSolver = async (params: ChallengesSolverParams): Promise<ChallengesOutcome> => {
     try {
         const client = TournamentionClient.getInstance();
         const guild = (await client).guilds.fetch(params.guildId);
@@ -259,7 +263,7 @@ export const formatChallengesDetails = (gamesAndChallenges: Map<string, Resolved
     return result;
 };
 
-const challengesSlashCommandDescriptions = new Map<ChallengesStatus, (o: ChallengesOutcome) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome>([
+export const challengesSlashCommandDescriptions = new Map<ChallengesStatus, (o: ChallengesOutcome) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome>([
     [ChallengesSpecificStatus.SUCCESS_DETAILS, (o: ChallengesOutcome) => {
         const oBody = (o as ChallengesSuccessDetailsOutcome).body;
         return {
@@ -267,6 +271,15 @@ const challengesSlashCommandDescriptions = new Map<ChallengesStatus, (o: Challen
                 .setTitle(`Challenges in ${oBody.tournament.name}`)
                 .setDescription(formatChallengesDetails(oBody.gamesAndChallenges))
                 .setThumbnail(oBody.serverDetails.icon)
+                .toJSON()
+            ],
+            components: [new ActionRowBuilder<ButtonBuilder>()
+                .addComponents(
+                    firstButton.getBuilder(),
+                    previousButton.getBuilder(),
+                    nextButton.getBuilder(),
+                    lastButton.getBuilder(),
+                )
                 .toJSON()
             ],
             ephemeral: true,

--- a/src/commands/slashcommands/challenges.ts
+++ b/src/commands/slashcommands/challenges.ts
@@ -136,6 +136,7 @@ export const challengesSolver = async (params: ChallengesSolverParams): Promise<
                 totalPages,
             },
             pagination: {
+                page: params.page,
                 totalPages,
             }
         } as ChallengesSuccessDetailsOutcome;
@@ -266,6 +267,23 @@ export const formatChallengesDetails = (gamesAndChallenges: Map<string, Resolved
 export const challengesSlashCommandDescriptions = new Map<ChallengesStatus, (o: ChallengesOutcome) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome>([
     [ChallengesSpecificStatus.SUCCESS_DETAILS, (o: ChallengesOutcome) => {
         const oBody = (o as ChallengesSuccessDetailsOutcome).body;
+        const components = [new ActionRowBuilder<ButtonBuilder>()
+            .addComponents(
+                firstButton.getBuilder(),
+                previousButton.getBuilder(),
+                nextButton.getBuilder(),
+                lastButton.getBuilder(),
+            )
+            .toJSON()
+        ];
+        // Disable the last and previous buttons intially when on the first page
+        const currentPage = (o as PaginatedOutcome).pagination.page;
+        components[0].components[0].disabled = currentPage === 0;
+        components[0].components[1].disabled = currentPage === 0;
+        // Disable the first and next buttons intially when on the last page
+        const totalPages = (o as PaginatedOutcome).pagination.totalPages;
+        components[0].components[2].disabled = currentPage === totalPages - 1;
+        components[0].components[3].disabled = currentPage === totalPages - 1;
         return {
             embeds: [new EmbedBuilder()
                 .setTitle(`Challenges in ${oBody.tournament.name}`)
@@ -273,15 +291,7 @@ export const challengesSlashCommandDescriptions = new Map<ChallengesStatus, (o: 
                 .setThumbnail(oBody.serverDetails.icon)
                 .toJSON()
             ],
-            components: [new ActionRowBuilder<ButtonBuilder>()
-                .addComponents(
-                    firstButton.getBuilder(),
-                    previousButton.getBuilder(),
-                    nextButton.getBuilder(),
-                    lastButton.getBuilder(),
-                )
-                .toJSON()
-            ],
+            components, 
             ephemeral: true,
         } as SlashCommandEmbedDescribedOutcome;
     }],

--- a/src/commands/slashcommands/create-challenge.ts
+++ b/src/commands/slashcommands/create-challenge.ts
@@ -240,7 +240,15 @@ const createChallengeSlashCommandDescriptions = new Map<CreateChallengeStatus, (
         else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_DUPLICATE) return ({
             userMessage: `❌ A challenge named **${oBody.value}** already exists in the tournament.`, ephemeral: true,
         });
-        else return ({
+        else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_TOO_LONG) {
+            let characterLimit = -1;
+            if (oBody.field === 'name') characterLimit = config.fieldCharacterLimits.challengeName;
+            else if (oBody.field === 'game') characterLimit = config.fieldCharacterLimits.game;
+            else if (oBody.field === 'description') characterLimit = config.fieldCharacterLimits.challengeDescription;
+            return {
+                userMessage: `❌ The ${oBody.field} must be ${characterLimit} characters or less. Please shorten it by ${oBody.value.length - characterLimit}.`, ephemeral: true,
+            };
+        } else return ({
             userMessage: `❌ This command failed due to a validation error.`, ephemeral: true,
         });
     }],

--- a/src/commands/slashcommands/create-tournament.ts
+++ b/src/commands/slashcommands/create-tournament.ts
@@ -176,7 +176,13 @@ const createTournamentSlashCommandDescriptions = new Map<CreateTournamentStatus,
         else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_DUPLICATE) return {
             userMessage: `❌ A tournament with the name **${oBody.value}** already exists.`, ephemeral: true
         };
-        else return {
+        else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_TOO_LONG) {
+            let characterLimit = -1;
+            if (oBody.field === 'name') characterLimit = config.fieldCharacterLimits.tournamentName;
+            return {
+                userMessage: `❌ The ${oBody.field} must be ${characterLimit} characters or less.`, ephemeral: true,
+            };
+        } else return {
             userMessage: `❌ This command failed unexpectedly due to a validation error.`, ephemeral: true
         };
     }],

--- a/src/commands/slashcommands/create-tournament.ts
+++ b/src/commands/slashcommands/create-tournament.ts
@@ -10,6 +10,7 @@ import { OptionValidationError, OptionValidationErrorStatus } from '../../types/
 import { ValueOf } from '../../types/typelogic.js';
 import { Constraint, validateConstraints } from '../architecture/validation.js';
 import { formatTournamentDetails } from './tournaments.js';
+import config from '../../config.js';
 
 /**
  * Alias for the first generic type of the command.
@@ -112,6 +113,13 @@ const createTournamentSlashCommandValidator = async (interaction: LimitedCommand
     ]);
     const optionConstraints = new Map<CommandInteractionOption | null, Constraint<ValueOf<CommandInteractionOption>>[]>([
         [name, [
+            // Ensure tournament name is <= 45 characters
+            {
+                category: OptionValidationErrorStatus.OPTION_TOO_LONG,
+                func: async function(option: ValueOf<CommandInteractionOption>): Promise<boolean> {
+                    return (option as string).length <= config.fieldCharacterLimits.tournamentName;
+                },
+            },
             // Ensure that no other Tournament exists with the same name
             {
                 category: OptionValidationErrorStatus.OPTION_DUPLICATE,

--- a/src/commands/slashcommands/create-tournament.ts
+++ b/src/commands/slashcommands/create-tournament.ts
@@ -45,11 +45,11 @@ type CreateTournamentOutcome = Outcome<T1, T2>;
 interface CreateTournamentSolverParams {
     guildId: string;
     name: string;
-    photoURI: string;
-    visible: boolean;
-    active: boolean;
-    statusDescription: string;
-    duration: string;
+    photoURI?: string | undefined;
+    visible?: boolean | undefined;
+    active?: boolean | undefined;
+    statusDescription?: string | undefined;
+    duration?: string | undefined;
 }
 
 /**
@@ -59,13 +59,18 @@ interface CreateTournamentSolverParams {
  */
 const createTournamentSolver = async (params: CreateTournamentSolverParams): Promise<CreateTournamentOutcome> => {
     try {
+        const photoURI = params.photoURI !== undefined ? params.photoURI : '';
+        const visibility = params.visible !== undefined ? params.visible : true;
+        const active = params.active !== undefined ? params.active : true;
+        const statusDescription = params.statusDescription !== undefined ? params.statusDescription : '';
+        const duration = params.duration !== undefined ? params.duration : '';
         const tournamentBuilder = new TournamentBuilder()
             .setName(params.name)
-            .setPhotoURI(params.photoURI)
-            .setVisibility(params.visible)
-            .setActive(params.active)
-            .setStatusDescription(params.statusDescription)
-            .setDuration(params.duration);
+            .setPhotoURI(photoURI)
+            .setVisibility(visibility)
+            .setActive(active)
+            .setStatusDescription(statusDescription)
+            .setDuration(duration);
         const tournament = await tournamentBuilder.buildForGuild(params.guildId);
         if (!tournament) return {
             status: OutcomeStatus.FAIL_UNKNOWN,

--- a/src/commands/slashcommands/edit-challenge.ts
+++ b/src/commands/slashcommands/edit-challenge.ts
@@ -287,7 +287,15 @@ const editChallengeSlashCommandDescriptions = new Map<EditChallengeStatus, (o: E
         else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_DUPLICATE) return ({
             userMessage: `❌ A challenge named **${oBody.value}** already exists in the tournament.`, ephemeral: true,
         });
-        else return ({
+        else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_TOO_LONG) {
+            let characterLimit = -1;
+            if (oBody.field === 'new-name') characterLimit = config.fieldCharacterLimits.challengeName;
+            else if (oBody.field === 'game') characterLimit = config.fieldCharacterLimits.game;
+            else if (oBody.field === 'description') characterLimit = config.fieldCharacterLimits.challengeDescription;
+            return {
+                userMessage: `❌ The ${oBody.field} must be ${characterLimit} characters or less. Please shorten it by ${oBody.value.length - characterLimit}.`, ephemeral: true,
+            };
+        } else return ({
             userMessage: `❌ This command failed due to a validation error.`, ephemeral: true,
         });
     }],

--- a/src/commands/slashcommands/edit-challenge.ts
+++ b/src/commands/slashcommands/edit-challenge.ts
@@ -11,6 +11,7 @@ import { OptionValidationError, OptionValidationErrorStatus } from '../../types/
 import { ValueOf } from '../../types/typelogic.js';
 import { Constraint, validateConstraints } from '../architecture/validation.js';
 import { getJudgeByGuildIdAndMemberId } from '../../backend/queries/profileQueries.js';
+import config from '../../config.js';
 
 /**
  * Alias for the first generic type of the command.
@@ -130,6 +131,8 @@ const editChallengeSlashCommandValidator = async (interaction: LimitedCommandInt
     const tournament = interaction.options.get('tournament', false);
     const difficulty = interaction.options.get('difficulty', false);
     const newName = interaction.options.get('new-name', false);
+    const game = interaction.options.get('game', false);
+    const description = interaction.options.get('description', false);
 
     const metadataConstraints = new Map<keyof LimitedCommandInteraction, Constraint<ValueOf<LimitedCommandInteraction>>[]>([
         ['member', [
@@ -179,6 +182,24 @@ const editChallengeSlashCommandValidator = async (interaction: LimitedCommandInt
                 }
             }
         ]],
+        [game, [
+            // Ensure game name is <= 30 characters
+            {
+                category: OptionValidationErrorStatus.OPTION_TOO_LONG,
+                func: async function(option: ValueOf<CommandInteractionOption>): Promise<boolean> {
+                    return (option as string).length <= config.fieldCharacterLimits.game;
+                },
+            },
+        ]],
+        [description, [
+            // Ensure description is <= 300 characters
+            {
+                category: OptionValidationErrorStatus.OPTION_TOO_LONG,
+                func: async function(option: ValueOf<CommandInteractionOption>): Promise<boolean> {
+                    return (option as string).length <= config.fieldCharacterLimits.challengeDescription;
+                },
+            },
+        ]],
         [difficulty, [
             // Ensure that the difficulty exists, if it was provided
             {
@@ -192,6 +213,13 @@ const editChallengeSlashCommandValidator = async (interaction: LimitedCommandInt
             },
         ]],
         [newName, [
+            // Ensure challenge name is <= 40 characters
+            {
+                category: OptionValidationErrorStatus.OPTION_TOO_LONG,
+                func: async function(option: ValueOf<CommandInteractionOption>): Promise<boolean> {
+                    return (option as string).length <= config.fieldCharacterLimits.challengeName;
+                },
+            },
             // Ensure that no challenge exists already with the new name in the tournament
             {
                 category: OptionValidationErrorStatus.OPTION_DUPLICATE,
@@ -205,8 +233,6 @@ const editChallengeSlashCommandValidator = async (interaction: LimitedCommandInt
         ]],
     ]);
 
-    const game = interaction.options.get('game', false)?.value as string;
-    const description = interaction.options.get('description', false)?.value as string;
     const visible = interaction.options.get('visible', false)?.value as boolean;
     try {
         await validateConstraints(interaction, metadataConstraints, optionConstraints);
@@ -228,8 +254,8 @@ const editChallengeSlashCommandValidator = async (interaction: LimitedCommandInt
         guildId: guildId,
         name: name.value as string,
         newName: newName ? newName.value as string : undefined,
-        game: game,
-        description: description,
+        game: game ? game.value as string : undefined,
+        description: description ? description.value as string : undefined,
         visible: visible,
         tournamentName: tournament ? tournament.value as string : undefined,
         difficulty: difficulty ? difficulty.value as string : undefined,

--- a/src/commands/slashcommands/edit-tournament.ts
+++ b/src/commands/slashcommands/edit-tournament.ts
@@ -10,6 +10,7 @@ import { Constraint, validateConstraints } from '../architecture/validation.js';
 import { OptionValidationError, OptionValidationErrorStatus } from '../../types/customError.js';
 import { formatTournamentDetails } from './tournaments.js';
 import { getJudgeByGuildIdAndMemberId } from '../../backend/queries/profileQueries.js';
+import config from '../../config.js';
 
 /**
  * Alias for the first generic type of the command.
@@ -126,6 +127,13 @@ const editTournamentSlashCommandValidator = async (interaction: LimitedCommandIn
             }
         ]],
         [newName, [
+            // Ensure tournament name is <= 45 characters
+            {
+                category: OptionValidationErrorStatus.OPTION_TOO_LONG,
+                func: async function(option: ValueOf<CommandInteractionOption>): Promise<boolean> {
+                    return (option as string).length <= config.fieldCharacterLimits.tournamentName;
+                },
+            },
             // Ensure that no other Tournament exists with the same name
             {
                 category: OptionValidationErrorStatus.OPTION_DUPLICATE,

--- a/src/commands/slashcommands/edit-tournament.ts
+++ b/src/commands/slashcommands/edit-tournament.ts
@@ -197,7 +197,13 @@ const editTournamentSlashCommandDescriptions = new Map<EditTournamentStatus, (o:
         if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_DUPLICATE) return {
             userMessage: `❌ A tournament with the name **${oBody.value}** already exists.`, ephemeral: true
         };
-        else return {
+        else if (oBody.constraint.category === OptionValidationErrorStatus.OPTION_TOO_LONG) {
+            let characterLimit = -1;
+            if (oBody.field === 'new-name') characterLimit = config.fieldCharacterLimits.tournamentName;
+            return {
+                userMessage: `❌ The ${oBody.field} must be ${characterLimit} characters or less.`, ephemeral: true,
+            };
+        } else return {
             userMessage: `❌ This command failed unexpectedly due to a validation error.`, ephemeral: true
         };
     }],

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ const config = {
     // The following character limits are required to ensure Discord embed messages have permissible
     // lengths. These should not be changed.
     'fieldCharacterLimits': {
-        'challengeName': 60,
+        'challengeName': 40,
         'challengeDescription': 300,
         'game': 30,
         'tournamentName': 45,

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,17 @@
 const config = {
     'featureFlags': {
         'privacyMode': false
+    },
+    // The following character limits are required to ensure Discord embed messages have permissible
+    // lengths. These should not be changed.
+    'fieldCharacterLimits': {
+        'challengeName': 60,
+        'challengeDescription': 300,
+        'game': 30,
+        'tournamentName': 45,
+    },
+    'pagination': {
+        'challengesPerPage': 10,
     }
 };
 

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,4 +1,4 @@
-import { BaseInteraction, ChatInputCommandInteraction } from 'discord.js';
+import { BaseInteraction, ButtonInteraction, ChatInputCommandInteraction } from 'discord.js';
 import { TournamentionClient } from '../types/client.js';
 import { CustomEvent } from '../types/customEvent.js';
 
@@ -21,8 +21,14 @@ const interactionCreate = new CustomEvent(
                 interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
             }
         } else if (interaction.isButton()) {
-            // TODO: Adapt code from Condemned Souls bot...
-            return;
+            const button = tournamentionClient.getButton((interaction as ButtonInteraction).customId);
+            try {
+                if (!button) return;
+                button.execute(interaction);
+            } catch (error) {
+                console.error(error);
+                interaction.reply({ content: 'There was an error while pressing this button!', ephemeral: true });
+            }
         }
     }
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import example2 from './example2.js';
 import { TournamentionClient } from './types/client.js';
 import { prepareCommands } from './util/commandHandler.js';
 import { prepareEvents } from './util/eventHandler.js';
+import { prepareButtons } from './util/buttonHandler.js';
 
 // Mongoose configuration setting (see https://github.com/Automattic/mongoose/issues/7150)
 mongoose.Schema.Types.String.checkRequired(v => v != null);
@@ -24,6 +25,9 @@ const client = await TournamentionClient.getInstance();
 
 // APPLICATION COMMANDS
 prepareCommands(client);
+
+// BUTTONS
+prepareButtons(client);
 
 // EVENTS
 prepareEvents(client);

--- a/src/types/cachedInteractions.ts
+++ b/src/types/cachedInteractions.ts
@@ -1,0 +1,63 @@
+import { Snowflake } from 'discord.js';
+import { ChallengesSolverParams, challengesSolver, challengesSlashCommandDescriptions, ChallengesStatus } from '../commands/slashcommands/challenges.js';
+import { TournamentionClient } from './client.js';
+import { defaultSlashCommandDescriptions } from './defaultSlashCommandDescriptions.js';
+import { SlashCommandDescribedOutcome, SlashCommandEmbedDescribedOutcome, Outcome, OutcomeStatus } from './outcome.js';
+
+enum CachedInteractionType {
+    Challenges = 'CHALLENGES',
+}
+
+type BaseCacheParams = {
+    client: TournamentionClient;
+    messageId: Snowflake;
+    senderId: string;
+}
+
+export type PaginatedCacheParams = BaseCacheParams & {
+    totalPages: number;
+}
+
+export interface CachedInteraction {
+    messageId: Snowflake;
+    senderId: string;
+    type: CachedInteractionType;
+}
+
+export class CachedChallengesInteraction implements CachedInteraction {
+    public type: CachedInteractionType = CachedInteractionType.Challenges;
+    constructor(
+        public readonly messageId: Snowflake,
+        public readonly senderId: string,
+        public readonly solverParams: ChallengesSolverParams,
+        public readonly totalPages: number,
+    ) {
+        this.messageId = messageId;
+        this.senderId = senderId;
+        this.solverParams = solverParams;
+    }
+
+    public setPage(page: number): void {
+        this.solverParams.page = page;
+    }
+
+    public async solveAgainAndDescribe(page: number): Promise<SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome> {
+        const outcome = await challengesSolver({ ...this.solverParams, page });
+        if (challengesSlashCommandDescriptions.has(outcome.status as ChallengesStatus)) return challengesSlashCommandDescriptions.get(outcome.status as ChallengesStatus)!(outcome);
+        // Fallback to trying default descriptions
+        const defaultOutcome = outcome as unknown as Outcome<string>;
+        if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
+            return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
+        } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
+    }
+
+    public static readonly cacheParams: PaginatedCacheParams & {
+        solverParams: ChallengesSolverParams;
+    };
+
+    public static async cache(cacheParams: typeof CachedChallengesInteraction.cacheParams): Promise<void> {
+        const { client, messageId, senderId, solverParams } = cacheParams;
+        const interaction = new CachedChallengesInteraction(messageId, senderId, solverParams, cacheParams.totalPages);
+        client.cacheInteraction(messageId, interaction);
+    }
+}

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,4 +1,4 @@
-import { Client, Collection, GatewayIntentBits } from 'discord.js';
+import { Client, Collection, GatewayIntentBits, Snowflake } from 'discord.js';
 import { RendezvousSlashCommand } from '../commands/architecture/rendezvousCommand.js';
 import { OutcomeTypeConstraint } from './outcome.js';
 import config from '../config.js';

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -2,6 +2,8 @@ import { Client, Collection, GatewayIntentBits } from 'discord.js';
 import { RendezvousSlashCommand } from '../commands/architecture/rendezvousCommand.js';
 import { OutcomeTypeConstraint } from './outcome.js';
 import config from '../config.js';
+import CustomButton from '../buttons/architecture/CustomButton.js';
+import { CachedInteraction } from './cachedInteractions.js';
 
 // Type alias for RendezvousSlashCommand with unknown generic parameters.
 type RdvsSlashCommandAlias = RendezvousSlashCommand<OutcomeTypeConstraint, unknown, unknown>;
@@ -11,9 +13,16 @@ type SlashCommandCollectionPair = {
     command: RdvsSlashCommandAlias;
 }
 
+type ButtonCollectionPair = {
+    customId: string;
+    button: CustomButton;
+}
+
 export class TournamentionClient extends Client {
     private static instance: TournamentionClient;
     private commands: Collection<string, RdvsSlashCommandAlias>;
+    private buttons: Collection<string, CustomButton>;
+    private interactionCache: Collection<string, CachedInteraction>;
 
     private constructor() {
         const intents = [GatewayIntentBits.Guilds];
@@ -22,6 +31,8 @@ export class TournamentionClient extends Client {
             intents,
         });
         this.commands = new Collection();
+        this.buttons = new Collection();
+        this.interactionCache = new Collection();
         TournamentionClient.instance = this;
     }
 
@@ -37,6 +48,28 @@ export class TournamentionClient extends Client {
 
     public getCommand(name: string): RdvsSlashCommandAlias | undefined {
         return this.commands.get(name);
+    }
+
+    public addButtons(buttons: ButtonCollectionPair[]): void {
+        buttons.forEach(btn => {
+            this.buttons.set(btn.customId, btn.button);
+        });
+    }
+
+    public getButton(customId: string): CustomButton | undefined {
+        return this.buttons.get(customId);
+    }
+
+    public cacheInteraction(messageId: Snowflake, cachedInteraction: CachedInteraction): void {
+        this.interactionCache.set(messageId, cachedInteraction);
+        setTimeout(() => {
+            this.interactionCache.delete(messageId);
+        }, 14 * 60 * 1000);
+        // TODO: Delete the interaction after < 15 minutes
+    }
+
+    public getCachedInteraction(messageId: Snowflake): CachedInteraction | undefined {
+        return this.interactionCache.get(messageId);
     }
 
     public static async getInstance(): Promise<TournamentionClient> {

--- a/src/types/customError.ts
+++ b/src/types/customError.ts
@@ -53,6 +53,7 @@ export enum OptionValidationErrorStatus {
     OPTION_DNE = 'OPTION_DNE', // option's associated data does not exist
     OPTION_UNDEFAULTABLE = 'OPTION_UNDEFAULTABLE', // optional option not provided and could not be defaulted
     OPTION_DUPLICATE = 'OPTION_DUPLICATE', // option provides a duplicate of existing data
+    OPTION_TOO_LONG = 'OPTION_TOO_LONG', // option provides data that exceeds a length limit
     OPTION_INVALID = 'OPTION_INVALID', // option provides invalid data. Use sparingly when other status codes are inapplicable
 }
 

--- a/src/types/outcome.ts
+++ b/src/types/outcome.ts
@@ -96,6 +96,7 @@ export type Outcome<T, U = void, V = PlaceholderOutcome> = OutcomeWithEmptyBody 
 
 export type PaginatedOutcome = {
     pagination: {
+        page: number,
         totalPages: number,
     }
 }

--- a/src/types/outcome.ts
+++ b/src/types/outcome.ts
@@ -93,3 +93,13 @@ type PlaceholderOutcome = {
 }
 
 export type Outcome<T, U = void, V = PlaceholderOutcome> = OutcomeWithEmptyBody | OutcomeWithMonoBody<T> | OutcomeWithDuoBody<T> | OutcomeWithDuoListBody<T, U> | OptionValidationErrorOutcome<T> | V;
+
+export type PaginatedOutcome = {
+    pagination: {
+        totalPages: number,
+    }
+}
+
+export const isPaginatedOutcome = (x: unknown): x is PaginatedOutcome => {
+    return (x as PaginatedOutcome).pagination !== undefined;
+};

--- a/src/util/buttonHandler.ts
+++ b/src/util/buttonHandler.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL, fileURLToPath } from 'url';
+import { TournamentionClient } from '../types/client.js';
+
+const addButtonsFromPath = async (client: TournamentionClient, buttonsPath: URL) => {
+    const commandFiles = fs.readdirSync(buttonsPath).filter(file => file.endsWith('.js') || file.endsWith('.ts'));
+    for (const file of commandFiles) {
+        const filePath = pathToFileURL(path.join(fileURLToPath(buttonsPath), file)).toString();
+        const button = (await import(filePath)).default;
+        client.addButtons([{ customId: button.getCustomId(), button }]);
+    }
+};
+
+export const prepareButtons = async (client: TournamentionClient) => {
+    const buttonsPath = pathToFileURL(path.join(process.cwd(), './src/buttons'));
+    // Buttons
+    await addButtonsFromPath(client, buttonsPath);
+};


### PR DESCRIPTION
Closes #91

This adds pagination to the embed command that needs it most urgently: /challenges. It works as you'd expect and has a good UX with first page, next page, previous page, and last page action row buttons that are dynamically enabled depending on current page and remaining pages. 

Implementing this was very involved. I took the route of mandating exactly 10 results per page, which, along with introducing character limits on certain fields, ensures that the embed message will never exceed Discord's length limit restrictions. It also makes pagination totally stable and computable in O(1) rather than O(n), as would be required if we tried cramming as much text into each embed as possible, leading to a different number of documents shown per page. That would've been a nightmare.

It required the infrastructure for buttons, which are elements of action rows in Discord. The API for these is pretty easy to use. They just exist as a distinct kind of interaction, which is handled otherwise very similarly to commands by the interactionCreate event handler.

The main challenge was caching command interactions so that buttons could edit their contents. In Condemned Souls, we did this by caching the interaction token keyed by the command's sender. This meant each user could have only one embed with buttons up at a time. In Tournamention, interaction messages are keyed by the message ID. This is because the token of the original interaction is not retrievable on a button press, and thus not editable when that button was pressed. Of course, CS got around this issue by using the aforementioned approach, which worked but had that limitation. The ID of the original message the button is attached to, on the other hand, is retrievable by the button, and thus editable. Now a user can have as many different challenge embeds up at once as they want!

The cached message (which has an interface with only one implementing class so far, which is the cached /challenges interaction) holds the information listed in the checklist below. This allows it to know where it is in the range of pages and how to exactly recreate the search used in the original interaction with the ability to sub in a new page number.

The changes made to the Rendezvous pattern to support automatic caching of interaction messages, when desired for the command, are non-breaking and, though initially made as a proof-of-concept rather than careful DX intention, are not bad in my opinion. It's basically just another optional generic parameter and another optional argument for the cacher class. It's probably not going to save you if you do something wrong (e.g. with how you write your cacher class) right now, though.

This PR also contains some miscellaneous fixes for issues I noticed when implementing pagination but were too minor to create separate PRs for. Notable ones include:
* The keycap emojis like 2️⃣ are now supported for numbers 1-5
* Fix for bug in /create-tournament when certain fields aren't given values

Here are my implementation notes:
# Checklist
* [X] Add pagination to query methods using skip and limit
* [X] Guarantee embed length limit is not exceeded
* [X] /create-tournament sets initial page to 0
* [X] Add interaction embed caching a la Condemned Souls, containing:
    * interaction token, sender, etc. essentials (`BaseCacheParams`)
    * Page count for that search (`PaginatedCacheParams`)
    * Current page (`PaginatedCacheParams`)
    * Current search (`cacheParams`)
* [x] Expire cached interaction after < 15 minutes
    * [X] Clear from cache
    * [X] Handle cases when cache misses and warn user of expired interaction
    * [ ] Delete the message (as seen in CS)
        * Just for user QoL if above subtask is completed, and ephemerals already get cleaned up sometimes
* [X] Add functional action row buttons
    * [X] Back
    * [X] Next
    * [X] First
    * [X] Last -- requires keeping track of the number of pages
* [X] Disable action row buttons when appropriate
* [X] Enforce length limits in commands with validation constraints

# Known Issues:
* If all challenges on the page are hidden, contestants get the error message "no visible challenges in tournament" with no way to change page