### PR TITLE
Add authenticated db login. Refactor validation to handle constraint errors

### DIFF
--- a/src/commands/architecture/validation.ts
+++ b/src/commands/architecture/validation.ts
@@ -20,7 +20,11 @@ export const validateConstraints = async (interaction: LimitedCommandInteraction
     // Using for ... of syntax because forEach does not support async functions.
     for (const [metadataField, constraints] of metadataConstraintMap) {
         for (const constraint of constraints) {
-            if (!(await constraint.func(interaction[metadataField]))) {
+            try {
+                if (!(await constraint.func(interaction[metadataField]))) {
+                    throw new Error();
+                }
+            } catch (err) {
                 throw new OptionValidationError<ValueOf<LimitedCommandInteraction>>(`Validation failed: check ${constraint.category} on metadata field ${metadataField} failed for value ${interaction[metadataField]}.`,
                     constraint,
                     metadataField,
@@ -62,7 +66,11 @@ export const validateConstraints = async (interaction: LimitedCommandInteraction
 
         // With the type of the option established, run the constraints on it.
         for (const constraint of constraints) {
-            if (!(await constraint.func(optionValue))) {
+            try {
+                if (!(await constraint.func(optionValue))) {
+                    throw new Error();
+                }
+            } catch (err) {
                 throw new OptionValidationError(`Validation failed: check ${constraint.category} on option ${option.name} failed for value ${optionValue}.`,
                     constraint,
                     option.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ mongoose.Schema.Types.String.checkRequired(v => v != null);
 // Database connection
 mongoose.connect(process.env.DB_URI as string, {
     dbName: 'tournamentionDB',
+    // Login to user/pass authenticated database
+    user: process.env.DB_USER,
+    pass: process.env.DB_PASS,
 })
     .then(() => {
         console.log('Database connection established');


### PR DESCRIPTION
This hotfixes lack of authentication credentials when connecting to a secure DB (as is required in a deployment context) and an oversight on validation check techniques that caused the bot to crash when encountering errors during constraint functions. The latter was the culprit for the crash when invalid emojis were entered in difficulty-related fields. In particular, validation constraints results that either evaluate to false or throw an error are now considered validation failures, which is what we wanted.

Of course, when running in your local environment, this means you'll need to either add authentication to your database and .env file (preferred) or remove the newly-added lines that attempt to use the credentials.