### PR TITLE
Add reply deferral to all embed commands

### DIFF
--- a/src/commands/architecture/rendezvousCommand.ts
+++ b/src/commands/architecture/rendezvousCommand.ts
@@ -61,8 +61,7 @@ export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, C ex
         if (isEmbedDescribedOutcome(describedOutcome)) {
             await interaction.editReply({ embeds: describedOutcome.embeds, components: describedOutcome.components });
             return;
-        }
-        else return interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
+        } else return interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
     }
 }
 

--- a/src/commands/architecture/rendezvousCommand.ts
+++ b/src/commands/architecture/rendezvousCommand.ts
@@ -56,8 +56,12 @@ export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, C ex
         }
     }
 
-    public static async simpleReplyer(interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome): Promise<InteractionResponse> {
-        if (isEmbedDescribedOutcome(describedOutcome)) return interaction.reply({ embeds: describedOutcome.embeds, components: describedOutcome.components, ephemeral: describedOutcome.ephemeral });
+    public static async simpleReplyer(interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome): Promise<InteractionResponse | void> {
+        if (isEmbedDescribedOutcome(describedOutcome)) await interaction.deferReply({ ephemeral: describedOutcome.ephemeral });
+        if (isEmbedDescribedOutcome(describedOutcome)) {
+            await interaction.editReply({ embeds: describedOutcome.embeds, components: describedOutcome.components });
+            return;
+        }
         else return interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
     }
 }


### PR DESCRIPTION
Closes #103 

Note that this is a temporary measure. Deferring the reply should be an opt-in thing for all commands that need them. I'm not sure if there are downsides to deferring reply to every command, but I imagine there's some consideration to be made.