### PR TITLE
Fix paginated embed commands crash

### DIFF
--- a/src/commands/architecture/rendezvousCommand.ts
+++ b/src/commands/architecture/rendezvousCommand.ts
@@ -63,7 +63,7 @@ export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, C ex
             if (interaction.deferred) {
                 await interaction.editReply({ embeds: describedOutcome.embeds, components: describedOutcome.components });
             } else {
-                await interaction.reply({ embeds: describedOutcome.embeds, components: describedOutcome.components, ephemeral: describedOutcome.ephemeral });
+                return await interaction.reply({ embeds: describedOutcome.embeds, components: describedOutcome.components, ephemeral: describedOutcome.ephemeral });
             }
         } else return interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
     }

--- a/src/commands/architecture/rendezvousCommand.ts
+++ b/src/commands/architecture/rendezvousCommand.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, ContextMenuCommandBuilder, InteractionResponse, SlashCommandBuilder } from 'discord.js';
+import { CommandInteraction, ContextMenuCommandBuilder, InteractionResponse, Message, SlashCommandBuilder } from 'discord.js';
 import { DescriptionMap, OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeTypeConstraint, PaginatedOutcome, SlashCommandDescribedOutcome, SlashCommandEmbedDescribedOutcome, isEmbedDescribedOutcome, isPaginatedOutcome, isValidationErrorOutcome } from '../../types/outcome.js';
 import { LimitedCommandInteraction, limitCommandInteraction } from '../../types/limitedCommandInteraction.js';
 import { defaultSlashCommandDescriptions } from '../../types/defaultSlashCommandDescriptions.js';
@@ -6,7 +6,7 @@ import { PaginatedCacheParams } from '../../types/cachedInteractions.js';
 
 export interface RendezvousCommand<O extends OutcomeTypeConstraint, S, T1> {
     readonly interfacer: SlashCommandBuilder | ContextMenuCommandBuilder | undefined;
-    readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome) => Promise<InteractionResponse | void>;
+    readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome) => Promise<InteractionResponse | Message>;
     readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome; // TODO: Generalize a DescribedOutcome type when/as needed
     readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>; // Generics for solverParams or (e.g. OptionValidationError)Outcome
     readonly solver: (solverParams: S) => Promise<O>;
@@ -17,7 +17,7 @@ export interface RendezvousCommand<O extends OutcomeTypeConstraint, S, T1> {
 export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, C extends PaginatedCacheParams | undefined = undefined> implements RendezvousCommand<O, S, T1> {
     constructor(
         public readonly interfacer: SlashCommandBuilder,
-        public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => Promise<InteractionResponse | void>,
+        public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => Promise<InteractionResponse | Message>,
         public readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome,
         public readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>,
         public readonly solver: (solverParams: S) => Promise<O>,
@@ -58,12 +58,12 @@ export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, C ex
         }
     }
 
-    public static async simpleReplyer(interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome): Promise<InteractionResponse | void> {
+    public static async simpleReplyer(interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome): Promise<InteractionResponse | Message> {
         if (isEmbedDescribedOutcome(describedOutcome)) {
             if (interaction.deferred) {
-                await interaction.editReply({ embeds: describedOutcome.embeds, components: describedOutcome.components });
+                return interaction.editReply({ embeds: describedOutcome.embeds, components: describedOutcome.components });
             } else {
-                return await interaction.reply({ embeds: describedOutcome.embeds, components: describedOutcome.components, ephemeral: describedOutcome.ephemeral });
+                return interaction.reply({ embeds: describedOutcome.embeds, components: describedOutcome.components, ephemeral: describedOutcome.ephemeral });
             }
         } else return interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
     }
@@ -94,7 +94,7 @@ export class SimpleRendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1
 export class RendezvousMessageCommand<O extends OutcomeTypeConstraint, S, T1> implements RendezvousCommand<O, S, T1> {
     constructor(
         public readonly interfacer: ContextMenuCommandBuilder,
-        public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => Promise<void>,
+        public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => Promise<InteractionResponse | Message>,
         public readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome,
         public readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>,
         public readonly solver: (solverParams: S) => Promise<O>,

--- a/src/commands/messagecommands/approve-submission.ts
+++ b/src/commands/messagecommands/approve-submission.ts
@@ -267,8 +267,8 @@ const approveSubmissionMessageCommandDescriber = (outcome: ApproveSubmissionOutc
 };
 
 const approveSubmissionMessageCommandReplyer = async (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => {
-    if (isEmbedDescribedOutcome(describedOutcome)) interaction.reply({ embeds: describedOutcome.embeds, components: describedOutcome.components, ephemeral: describedOutcome.ephemeral });
-    else interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
+    if (isEmbedDescribedOutcome(describedOutcome)) return interaction.reply({ embeds: describedOutcome.embeds, components: describedOutcome.components, ephemeral: describedOutcome.ephemeral });
+    else return interaction.reply({ content: describedOutcome.userMessage, ephemeral: describedOutcome.ephemeral });
 };
 
 const ApproveSubmissionCommand = new RendezvousMessageCommand<ApproveSubmissionOutcome, ApproveSubmissionSolverParams, T1>(


### PR DESCRIPTION
Closes #106

This fixes the crash described in #106 and does a small refactor to standardize return types of replyer methods across all kinds of Rendezvous commands.