### PR TITLE
Fix discord promise error crash

### DIFF
--- a/src/commands/architecture/rendezvousCommand.ts
+++ b/src/commands/architecture/rendezvousCommand.ts
@@ -50,8 +50,12 @@ export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, C ex
         // Describer step
         const describedOutcome = this.describer(outcome);
         // Replyer step
-        const message = await this.replyer(interaction, describedOutcome);
-
+        const message = await this.replyer(interaction, describedOutcome)
+            .then(message => message)
+            .catch(error => {
+                console.error(`Error in RendezvousSlashCommand replyer step: ${error}`);
+                return;
+            });
         // Cache interaction
         if (this.cacher && isPaginatedOutcome(outcome)) {
             this.cacher({ client: interaction.client, messageId: (message as InteractionResponse).id, senderId: interaction.user.id, solverParams: solverParamsOrValidationErrorOutcome as S, totalPages: (outcome as unknown as PaginatedOutcome).pagination.totalPages} as unknown as C);
@@ -123,6 +127,10 @@ export class RendezvousMessageCommand<O extends OutcomeTypeConstraint, S, T1> im
         // Describer step
         const describedOutcome = this.describer(outcome);
         // Replyer step
-        await this.replyer(interaction, describedOutcome);
+        await this.replyer(interaction, describedOutcome)
+            .catch(error => {
+                console.error(`Error in RendezvousMessageCommand replyer step: ${error}`);
+                return;
+            });
     }
 }


### PR DESCRIPTION
Closes #109 

This is a big improvement for general availability of the bot. The change itself is small -- it just adds a catch clause to the promise returned by a Discord.js frontend method's calls. What it does is keeping the bot online rather than crashing when interactions take too long to process. Remember that this crash scenario would often arise due to currently running the bot with a weak-performance self-host setup, but it could happen at any point e.g. receiving a large number of requests at once. In any scenario where an interaction cannot be replied to in time, the bot will no longer crash.