### PR TITLE
Fix code quality issues via Sonarscanner

### DIFF
--- a/src/backend/queries/challengeQueries.ts
+++ b/src/backend/queries/challengeQueries.ts
@@ -10,7 +10,7 @@ import config from '../../config.js';
 
 // READ / GET
 export const getChallengeById = async (id: Ref<Challenge> | string): Promise<ChallengeDocument | null> => {
-    return ChallengeModel.findById(id);
+    return ChallengeModel.findById(id).exec();
 };
 
 export const getChallengeOfTournamentByName = async (name: string, tournament: TournamentDocument): Promise<ChallengeDocument | null> => {
@@ -21,7 +21,7 @@ export const getChallengeOfTournamentByName = async (name: string, tournament: T
 };
 
 export const getChallengesOfTournament = async (tournamentId: Ref<Tournament> | string): Promise<ChallengeDocument[]> => {
-    const tournament = await TournamentModel.findById(tournamentId);
+    const tournament = await TournamentModel.findById(tournamentId).exec();
     return ChallengeModel.find().where('_id').in(tournament!.challenges).exec();
 };
 
@@ -32,7 +32,7 @@ type ChallengesAndPageCount = {
 
 export const getChallengesOfTournamentPaged = async (tournamentId: Ref<Tournament> | string, page: number): Promise<ChallengesAndPageCount> => {
     const pageLimit = config.pagination.challengesPerPage;
-    const tournament = await TournamentModel.findById(tournamentId);
+    const tournament = await TournamentModel.findById(tournamentId).exec();
     const query = ChallengeModel
         .find()
         .where('_id').in(tournament!.challenges)
@@ -44,13 +44,13 @@ export const getChallengesOfTournamentPaged = async (tournamentId: Ref<Tournamen
 };
 
 export const getChallengesOfTournamentByGame = async (tournamentId: Ref<Tournament> | string, game: string): Promise<ChallengeDocument[]> => {
-    const tournament = await TournamentModel.findById(tournamentId);
+    const tournament = await TournamentModel.findById(tournamentId).exec();
     return ChallengeModel.find().where('_id').in(tournament!.challenges).where('game').equals(game).exec();
 };
 
 export const getChallengesOfTournamentByGamePaged = async (tournamentId: Ref<Tournament> | string, game: string, page: number): Promise<ChallengesAndPageCount> => {
     const pageLimit = config.pagination.challengesPerPage;
-    const tournament = await TournamentModel.findById(tournamentId);
+    const tournament = await TournamentModel.findById(tournamentId).exec();
     const query = ChallengeModel
         .find()
         .where('_id').in(tournament!.challenges)
@@ -63,7 +63,7 @@ export const getChallengesOfTournamentByGamePaged = async (tournamentId: Ref<Tou
 };
 
 export const getChallengesOfTournamentByDifficulty = async (tournamentId: Ref<Tournament> | string, difficulty: Ref<Difficulty> | string): Promise<ChallengeDocument[]> => {
-    const tournament = await TournamentModel.findById(tournamentId);
+    const tournament = await TournamentModel.findById(tournamentId).exec();
     return ChallengeModel.find().where('_id').in(tournament!.challenges).where('difficulty').equals(difficulty).exec();
 };
 
@@ -71,7 +71,7 @@ export const getChallengesOfTournamentByDifficulty = async (tournamentId: Ref<To
 // const updateChallengeByName = async (challenge)
 
 export const updateChallengeById = async (id: ObjectId, update: UpdateChallengeParams): Promise<ChallengeDocument | null> => {
-    return ChallengeModel.findByIdAndUpdate(id, { $set: update });
+    return ChallengeModel.findByIdAndUpdate(id, { $set: update }).exec();
 };
 
 // DELETE

--- a/src/backend/queries/guildSettingsQueries.ts
+++ b/src/backend/queries/guildSettingsQueries.ts
@@ -9,7 +9,7 @@ export const createGuildSettings = async (guildID: string): Promise<GuildSetting
 
 // READ / GET
 export const getGuildSettings = async (guildID: string): Promise<GuildSettingsDocument | null> => {
-    return GuildSettingsModel.findOne({ guildID: guildID });
+    return GuildSettingsModel.findOne({ guildID: guildID }).exec();
 };
 
 export const getOrCreateGuildSettings = async (guildID: string): Promise<GuildSettingsDocument> => {

--- a/src/backend/queries/profileQueries.ts
+++ b/src/backend/queries/profileQueries.ts
@@ -37,21 +37,21 @@ export const createJudge = async (guildId: string, memberId: string): Promise<Ju
  * @returns The new or existing Contestant document.
  */
 export const getOrCreateContestant = async (guildId: string, memberId: string): Promise<ContestantDocument> => {
-    const contestant = await ContestantModel.findOne({ guildID: guildId, userID: memberId });
+    const contestant = await ContestantModel.findOne({ guildID: guildId, userID: memberId }).exec();
     if (contestant) return contestant;
     else return createContestant(guildId, memberId);
 };
 
 export const getContestantByGuildIdAndMemberId = async (guildId: string, memberId: string): Promise<ContestantDocument | null> => {
-    return ContestantModel.findOne({ guildID: guildId, userID: memberId });
+    return ContestantModel.findOne({ guildID: guildId, userID: memberId }).exec();
 };
 
 export const getContestantById = async (id: Ref<Contestant> | string): Promise<ContestantDocument | null> => {
-    return ContestantModel.findById(id);
+    return ContestantModel.findById(id).exec();
 };
 
 export const getJudgeById = async (id: Ref<Judge> | string): Promise<JudgeDocument | null> => {
-    return JudgeModel.findById(id);
+    return JudgeModel.findById(id).exec();
 };
 
 export const getJudgeByGuildIdAndMemberId = async (guildId: string, memberId: string): Promise<JudgeDocument | null> => {

--- a/src/backend/queries/submissionQueries.ts
+++ b/src/backend/queries/submissionQueries.ts
@@ -84,7 +84,7 @@ export const getSubmissionInCurrentTournamentFromContestantWithLink = async (gui
 
 export const getPendingSubmissionsOfTournamentPaged = async (tournamentId: Ref<Tournament> | string, page: number) => {
     const pageLimit = config.pagination.pendingSubmissionsPerPage;
-    const tournament = await TournamentModel.findById(tournamentId);
+    const tournament = await TournamentModel.findById(tournamentId).exec();
     const query = SubmissionModel
         .find()
         .where('challengeID').in(tournament!.challenges)

--- a/src/backend/queries/tournamentQueries.ts
+++ b/src/backend/queries/tournamentQueries.ts
@@ -101,15 +101,15 @@ export class TournamentBuilder {
 
 // READ / GET
 export const getTournamentById = async (id: ObjectId): Promise<TournamentDocument | null> => {
-    return TournamentModel.findById(id);
+    return TournamentModel.findById(id).exec();
 };
 
 export const getTournamentsByGuild = async (guildID: string): Promise<TournamentDocument[] | null> => {
-    return TournamentModel.find({ guildID: guildID });
+    return TournamentModel.find({ guildID: guildID }).exec();
 };
 
 export const getTournamentByName = async (guildID: string, name: string): Promise<TournamentDocument | null> => {
-    return TournamentModel.findOne({ guildID: guildID, name: name });
+    return TournamentModel.findOne({ guildID: guildID, name: name }).exec();
 };
 
 const explicitSupportedEmojis = ['2️⃣', '3️⃣', '4️⃣', '5️⃣'];
@@ -121,7 +121,7 @@ export const isSingleEmoji = (emoji: string): boolean => {
 };
 
 export const getDifficultyByID = async (id: Ref<Difficulty> | string): Promise<DifficultyDocument | null> => {
-    return DifficultyModel.findById(id);
+    return DifficultyModel.findById(id).exec();
 };
 
 export const getDifficultyByEmoji = async (tournament: TournamentDocument, emoji: string): Promise<DifficultyDocument | null> => {
@@ -137,7 +137,7 @@ export const getDifficultyByEmoji = async (tournament: TournamentDocument, emoji
 };
 
 export const getDifficultiesOfTournament = async (tournamentId: Ref<Tournament> | string): Promise<DifficultyDocument[]> => {
-    const tournament = await TournamentModel.findById(tournamentId);
+    const tournament = await TournamentModel.findById(tournamentId).exec();
     return DifficultyModel.find().where('_id').in(tournament!.difficulties).exec();
 };
 
@@ -147,7 +147,7 @@ export const updateTournament = async (id: ObjectId, update: UpdateTournamentPar
 };
 
 export const addChallengeToTournament = async (tournamentID: Ref<Tournament>, challenge: ChallengeDocument): Promise<TournamentDocument> => {
-    const tournament = await TournamentModel.findById(tournamentID);
+    const tournament = await TournamentModel.findById(tournamentID).exec();
     if (!tournament) throw new Error('Error in addChallengeToTournament: Tournament not found.');
     const resolvedChallenges = await tournament.get('resolvingChallenges') as ChallengeDocument[];
     for (const existingChallenge of resolvedChallenges) {
@@ -162,7 +162,7 @@ export const addChallengeToTournament = async (tournamentID: Ref<Tournament>, ch
 // };
 
 const addDifficultyToTournament = async (tournamentID: Ref<Tournament>, difficulty: DifficultyDocument): Promise<TournamentDocument> => {
-    const tournament = await TournamentModel.findById(tournamentID);
+    const tournament = await TournamentModel.findById(tournamentID).exec();
     if (!tournament) throw new Error('Error in addDifficultyToTournament: Tournament not found.');
     const resolvedDifficulties = await tournament.get('resolvingDifficulties') as DifficultyDocument[];
     for (const existingDifficulty of resolvedDifficulties) {
@@ -175,5 +175,5 @@ const addDifficultyToTournament = async (tournamentID: Ref<Tournament>, difficul
 // DELETE
 // TODO: Delete all challenges and difficulties from tournament
 export const deleteTournament = async (id: Ref<Tournament>): Promise<TournamentDocument | null> => {
-    return TournamentModel.findByIdAndDelete(id);
+    return TournamentModel.findByIdAndDelete(id).exec();
 };

--- a/src/backend/schemas/guildsettings.ts
+++ b/src/backend/schemas/guildsettings.ts
@@ -11,7 +11,7 @@ export class GuildSettings {
 
     public async getCurrentTournament(): Promise<TournamentDocument | null> {
         // TODO: test performance WRT frequent .toObject() calls, would a separate array of Tournament be faster?
-        const guildTournaments = await TournamentModel.find({ guildID: this.guildID });
+        const guildTournaments = await TournamentModel.find({ guildID: this.guildID }).exec();
         const activeTournaments = guildTournaments
             .filter((t: TournamentDocument) => {
                 return t.toObject().active;

--- a/src/backend/schemas/tournament.ts
+++ b/src/backend/schemas/tournament.ts
@@ -39,10 +39,10 @@ export const TournamentModel = getModelForClass(Tournament);
 
 TournamentModel.schema.virtual('resolvingChallenges').get(function() {
     // If this doesn't work then try returning the promise and rename this resolvingChallenges
-    return ChallengeModel.find({ _id: { $in: this.challenges } });
+    return ChallengeModel.find({ _id: { $in: this.challenges } }).exec();
 });
 
 TournamentModel.schema.virtual('resolvingDifficulties').get(function() {
     // If this doesn't work then try returning the promise and rename this resolvingDifficulties
-    return DifficultyModel.find({ _id: { $in: this.difficulties } });
+    return DifficultyModel.find({ _id: { $in: this.difficulties } }).exec();
 });

--- a/src/types/customDocument.ts
+++ b/src/types/customDocument.ts
@@ -41,7 +41,7 @@ export class ResolvedChallenge {
         this._id = this.document._id;
         this.name = this.document.name;
         this.description = this.document.description;
-        this.difficulty = await DifficultyModel.findById(this.document.difficulty);
+        this.difficulty = await DifficultyModel.findById(this.document.difficulty).exec();
         this.game = this.document.game;
         this.visibility = this.document.visibility;
         return this;
@@ -103,10 +103,10 @@ export class ResolvedSubmission {
 
     public async make(): Promise<ResolvedSubmission> {
         this._id = this.document._id;
-        const challenge = await ChallengeModel.findById(this.document.challengeID);
+        const challenge = await ChallengeModel.findById(this.document.challengeID).exec();
         if (!challenge) throw new Error(`Error in customDocument.ts: Could not find challenge ${this.document.challengeID}`);
         this.challenge = await (new ResolvedChallenge(challenge)).make();
-        const contestant = await ContestantModel.findById(this.document.contestantID);
+        const contestant = await ContestantModel.findById(this.document.contestantID).exec();
         if (!contestant) throw new Error(`Error in customDocument.ts: Could not find contestant ${this.document.contestantID}`);
         this.contestant = contestant;
         this.proof = this.document.proof;


### PR DESCRIPTION
Awaiting a non-Promise is flagged as a high-severity maintainability issue by Sonarscanner. I disagree with the description of severity for the flagged usage, but there is a related Mongoose issue this brings up that this change fixes: Mongoose Queries are not Promises, but they are thenable. This means using the await keyword on them does produce the intended behavior, which is why I did it previously. However, to both alleviate this issue of technicality and to ensure consistency with other Mongoose query calls that do use .exec(), all Mongoose Queries that are returned or awaited are now suffixed with .exec() so that they evaluate to Promises. This is what the [Mongoose documentation on the topic](https://mongoosejs.com/docs/async-await.html) advises.

There are other flagged issues but almost all are either irrelevant or wrong about how Mongoose/Typegoose works.