### PR TITLE
Refactor interaction caching, client class, Rendezvous pattern

### DIFF
--- a/src/buttons/first.ts
+++ b/src/buttons/first.ts
@@ -1,8 +1,7 @@
 import { ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
 import CustomButton from './architecture/CustomButton.js';
-import { TournamentionClient } from '../types/client.js';
 import { isEmbedDescribedOutcome } from '../types/outcome.js';
-import { CacherCachedInteraction } from '../types/cachedInteractions.js';
+import { InteractionCacheServiceLocator } from '../types/interactionCacheServiceLocator.js';
 
 const firstButton = new CustomButton(
     new ButtonBuilder()
@@ -11,8 +10,7 @@ const firstButton = new CustomButton(
         .setStyle(ButtonStyle.Primary),
     async (interaction: ButtonInteraction) => {
         // Find cached data for this original interaction
-        const client = await TournamentionClient.getInstance();
-        const cached = client.getCachedInteraction(interaction.message.interaction!.id) as CacherCachedInteraction;
+        const cached = InteractionCacheServiceLocator.getService().getCachedInteraction(interaction.message.interaction!.id);
         if (!cached) {
             await interaction.reply({ content: 'This interaction has expired.', ephemeral: true });
             return;

--- a/src/buttons/last.ts
+++ b/src/buttons/last.ts
@@ -1,8 +1,7 @@
 import { ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
 import CustomButton from './architecture/CustomButton.js';
-import { TournamentionClient } from '../types/client.js';
 import { isEmbedDescribedOutcome } from '../types/outcome.js';
-import { CacherCachedInteraction } from '../types/cachedInteractions.js';
+import { InteractionCacheServiceLocator } from '../types/interactionCacheServiceLocator.js';
 
 const lastButton = new CustomButton(
     new ButtonBuilder()
@@ -11,8 +10,7 @@ const lastButton = new CustomButton(
         .setStyle(ButtonStyle.Primary),
     async (interaction: ButtonInteraction) => {
         // Find cached data for this original interaction
-        const client = await TournamentionClient.getInstance();
-        const cached = client.getCachedInteraction(interaction.message.interaction!.id) as CacherCachedInteraction;
+        const cached = InteractionCacheServiceLocator.getService().getCachedInteraction(interaction.message.interaction!.id);
         if (!cached) {
             await interaction.reply({ content: 'This interaction has expired!', ephemeral: true });
             return;

--- a/src/buttons/next.ts
+++ b/src/buttons/next.ts
@@ -1,8 +1,7 @@
 import { ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
 import CustomButton from './architecture/CustomButton.js';
-import { CacherCachedInteraction } from '../types/cachedInteractions.js';
-import { TournamentionClient } from '../types/client.js';
 import { isEmbedDescribedOutcome } from '../types/outcome.js';
+import { InteractionCacheServiceLocator } from '../types/interactionCacheServiceLocator.js';
 
 const nextButton = new CustomButton(
     new ButtonBuilder()
@@ -11,8 +10,7 @@ const nextButton = new CustomButton(
         .setStyle(ButtonStyle.Primary),
     async (interaction: ButtonInteraction) => {
         // Find cached data for this original interaction
-        const client = await TournamentionClient.getInstance();
-        const cached = client.getCachedInteraction(interaction.message.interaction!.id) as CacherCachedInteraction;
+        const cached = InteractionCacheServiceLocator.getService().getCachedInteraction(interaction.message.interaction!.id);
         if (!cached) {
             await interaction.reply({ content: 'This interaction has expired!', ephemeral: true });
             return;

--- a/src/buttons/previous.ts
+++ b/src/buttons/previous.ts
@@ -1,8 +1,7 @@
 import { ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
 import CustomButton from './architecture/CustomButton.js';
-import { CacherCachedInteraction } from '../types/cachedInteractions.js';
-import { TournamentionClient } from '../types/client.js';
 import { isEmbedDescribedOutcome } from '../types/outcome.js';
+import { InteractionCacheServiceLocator } from '../types/interactionCacheServiceLocator.js';
 
 const previousButton = new CustomButton(
     new ButtonBuilder()
@@ -11,8 +10,7 @@ const previousButton = new CustomButton(
         .setStyle(ButtonStyle.Primary),
     async (interaction: ButtonInteraction) => {
         // Find cached data for this original interaction
-        const client = await TournamentionClient.getInstance();
-        const cached = client.getCachedInteraction(interaction.message.interaction!.id) as CacherCachedInteraction;
+        const cached = InteractionCacheServiceLocator.getService().getCachedInteraction(interaction.message.interaction!.id);
         if (!cached) {
             await interaction.reply({ content: 'This interaction has expired!', ephemeral: true });
             return;

--- a/src/commands/architecture/rendezvousCommand.ts
+++ b/src/commands/architecture/rendezvousCommand.ts
@@ -34,8 +34,7 @@ export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1> impl
     }
 
     public async execute(interaction: CommandInteraction) {
-        // Temporary fix for slow leaderboard command response (#103)
-        if (interaction.commandName === 'leaderboard') await interaction.deferReply({ ephemeral: true });
+        if (this.defer) await interaction.deferReply({ ephemeral: true });
         // Preprocessing step: remove unneeded properties from the interaction
         const limitedCommandInteraction = limitCommandInteraction(interaction);
         // Validator step

--- a/src/commands/architecture/rendezvousCommand.ts
+++ b/src/commands/architecture/rendezvousCommand.ts
@@ -2,7 +2,7 @@ import { CommandInteraction, ContextMenuCommandBuilder, InteractionResponse, Mes
 import { DescriptionMap, OptionValidationErrorOutcome, Outcome, OutcomeStatus, OutcomeTypeConstraint, PaginatedOutcome, SlashCommandDescribedOutcome, SlashCommandEmbedDescribedOutcome, isEmbedDescribedOutcome, isPaginatedOutcome, isValidationErrorOutcome } from '../../types/outcome.js';
 import { LimitedCommandInteraction, limitCommandInteraction } from '../../types/limitedCommandInteraction.js';
 import { defaultSlashCommandDescriptions } from '../../types/defaultSlashCommandDescriptions.js';
-import { PaginatedCacheParams } from '../../types/cachedInteractions.js';
+import { CachedCommandInteraction } from '../../types/cachedInteractions.js';
 
 export interface RendezvousCommand<O extends OutcomeTypeConstraint, S, T1> {
     readonly interfacer: SlashCommandBuilder | ContextMenuCommandBuilder | undefined;
@@ -14,21 +14,23 @@ export interface RendezvousCommand<O extends OutcomeTypeConstraint, S, T1> {
     readonly execute: (interaction: CommandInteraction) => Promise<void>;
 }
 
-export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, C extends PaginatedCacheParams | undefined = undefined> implements RendezvousCommand<O, S, T1> {
+export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1> implements RendezvousCommand<O, S, T1> {
     constructor(
         public readonly interfacer: SlashCommandBuilder,
         public readonly replyer: (interaction: CommandInteraction, describedOutcome: SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome) => Promise<InteractionResponse | Message>,
         public readonly describer: (outcome: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome,
         public readonly validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>,
         public readonly solver: (solverParams: S) => Promise<O>,
-        public readonly cacher?: ((cacheParams: C) => Promise<void>) | undefined,
+        public readonly defer?: boolean | undefined,
+        public readonly cache?: boolean | undefined,
     ) {
         this.interfacer = interfacer;
         this.replyer = replyer;
         this.describer = describer;
         this.validator = validator;
         this.solver = solver;
-        this.cacher = cacher;
+        this.defer = defer as boolean;
+        this.cache = cache as boolean;
     }
 
     public async execute(interaction: CommandInteraction) {
@@ -57,8 +59,9 @@ export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, C ex
                 return;
             });
         // Cache interaction
-        if (this.cacher && isPaginatedOutcome(outcome)) {
-            this.cacher({ client: interaction.client, messageId: (message as InteractionResponse).id, senderId: interaction.user.id, solverParams: solverParamsOrValidationErrorOutcome as S, totalPages: (outcome as unknown as PaginatedOutcome).pagination.totalPages} as unknown as C);
+        if (this.cache && isPaginatedOutcome(outcome)) {
+            //this.cacher({ client: interaction.client, messageId: (message as InteractionResponse).id, senderId: interaction.user.id, solverParams: solverParamsOrValidationErrorOutcome as S, totalPages: (outcome as unknown as PaginatedOutcome).pagination.totalPages} as unknown as C);
+            new CachedCommandInteraction(this, (message as InteractionResponse).id, interaction.user.id, solverParamsOrValidationErrorOutcome as S, (outcome as unknown as PaginatedOutcome).pagination.totalPages).cache();
         }
     }
 
@@ -73,16 +76,17 @@ export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, C ex
     }
 }
 
-export class SimpleRendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, CommandStatus = OutcomeStatus, C extends PaginatedCacheParams | undefined = undefined> extends RendezvousSlashCommand<O, S, T1, C> {
+export class SimpleRendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1, CommandStatus = OutcomeStatus> extends RendezvousSlashCommand<O, S, T1> {
     constructor(
         interfacer: SlashCommandBuilder,
         descriptions: DescriptionMap<CommandStatus, O>,
         validator: (interaction: LimitedCommandInteraction) => Promise<S | OptionValidationErrorOutcome<T1>>,
         solver: (solverParams: S) => Promise<O>,
-        cacher?: ((cacheParams: C) => Promise<void>) | undefined,
+        defer?: boolean | undefined,
+        cache?: boolean | undefined,
     ) {
         const describer = (outcome: O) => this.simpleDescriber(outcome, descriptions);
-        super(interfacer, RendezvousSlashCommand.simpleReplyer, describer, validator, solver, cacher);
+        super(interfacer, RendezvousSlashCommand.simpleReplyer, describer, validator, solver, defer, cache);
     }
 
     private simpleDescriber(outcome: O, descriptions: Map<CommandStatus, (o: O) => SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome>) {

--- a/src/commands/architecture/rendezvousCommand.ts
+++ b/src/commands/architecture/rendezvousCommand.ts
@@ -59,7 +59,6 @@ export class RendezvousSlashCommand<O extends OutcomeTypeConstraint, S, T1> impl
             });
         // Cache interaction
         if (this.cache && isPaginatedOutcome(outcome)) {
-            //this.cacher({ client: interaction.client, messageId: (message as InteractionResponse).id, senderId: interaction.user.id, solverParams: solverParamsOrValidationErrorOutcome as S, totalPages: (outcome as unknown as PaginatedOutcome).pagination.totalPages} as unknown as C);
             new CachedCommandInteraction(this, (message as InteractionResponse).id, interaction.user.id, solverParamsOrValidationErrorOutcome as S, (outcome as unknown as PaginatedOutcome).pagination.totalPages).cache();
         }
     }

--- a/src/commands/slashcommands/challenges.ts
+++ b/src/commands/slashcommands/challenges.ts
@@ -10,7 +10,6 @@ import { getCurrentTournament } from '../../backend/queries/guildSettingsQueries
 import { getChallengesOfTournamentByDifficulty, getChallengesOfTournamentByGame, getChallengesOfTournamentByGamePaged, getChallengesOfTournamentPaged } from '../../backend/queries/challengeQueries.js';
 import { getJudgeByGuildIdAndMemberId } from '../../backend/queries/profileQueries.js';
 import { ChallengeDocument, ResolvedChallenge, ResolvedTournament } from '../../types/customDocument.js';
-import { CachedChallengesInteraction } from '../../types/cachedInteractions.js';
 import { TournamentionClient } from '../../types/client.js';
 import firstButton from '../../buttons/first.js';
 import lastButton from '../../buttons/last.js';
@@ -324,7 +323,7 @@ export const challengesSlashCommandDescriptions = new Map<ChallengesStatus, (o: 
     })],
 ]);
 
-const ChallengesCommand = new SimpleRendezvousSlashCommand<ChallengesOutcome, ChallengesSolverParams, T1, ChallengesStatus, typeof CachedChallengesInteraction.cacheParams>(
+const ChallengesCommand = new SimpleRendezvousSlashCommand<ChallengesOutcome, ChallengesSolverParams, T1, ChallengesStatus>(
     new SlashCommandBuilder()
         .setName('challenges')
         .setDescription('Show the challenges posted for a tournament.')
@@ -335,7 +334,8 @@ const ChallengesCommand = new SimpleRendezvousSlashCommand<ChallengesOutcome, Ch
     challengesSlashCommandDescriptions,
     challengesSlashCommandValidator,
     challengesSolver,
-    CachedChallengesInteraction.cache,
+    false,
+    true,
 );
 
 export default ChallengesCommand;

--- a/src/commands/slashcommands/leaderboard.ts
+++ b/src/commands/slashcommands/leaderboard.ts
@@ -189,6 +189,7 @@ const LeaderboardCommand = new SimpleRendezvousSlashCommand<LeaderboardOutcome, 
     leaderboardSlashCommandDescriptions,
     leaderboardSlashCommandValidator,
     leaderboardSolver,
+    true,
 );
 
 export default LeaderboardCommand;

--- a/src/commands/slashcommands/pending-submissions.ts
+++ b/src/commands/slashcommands/pending-submissions.ts
@@ -7,7 +7,6 @@ import { Constraint, validateConstraints, ALWAYS_OPTION_CONSTRAINT } from '../ar
 import { getTournamentByName } from '../../backend/queries/tournamentQueries.js';
 import { OptionValidationError, OptionValidationErrorStatus } from '../../types/customError.js';
 import { getCurrentTournament } from '../../backend/queries/guildSettingsQueries.js';
-import { CachedPendingSubmissionsInteraction } from '../../types/cachedInteractions.js';
 import { PendingSubmissionsOutcome, PendingSubmissionsSolverParams, PendingSubmissionsStatus, T1, pendingSubmissionsSlashCommandDescriptions, pendingSubmissionsSolver } from './pending-submissions/pending-submissions-exports.js';
 
 
@@ -62,7 +61,7 @@ const pendingSubmissionsSlashCommandValidator = async (interaction: LimitedComma
     };
 };
 
-const PendingSubmissionsCommand = new SimpleRendezvousSlashCommand<PendingSubmissionsOutcome, PendingSubmissionsSolverParams, T1, PendingSubmissionsStatus, typeof CachedPendingSubmissionsInteraction.cacheParams>(
+const PendingSubmissionsCommand = new SimpleRendezvousSlashCommand<PendingSubmissionsOutcome, PendingSubmissionsSolverParams, T1, PendingSubmissionsStatus>(
     new SlashCommandBuilder()
         .setName('pending-submissions')
         .setDescription('Show the submissions waiting for review in the tournament.')
@@ -70,7 +69,8 @@ const PendingSubmissionsCommand = new SimpleRendezvousSlashCommand<PendingSubmis
     pendingSubmissionsSlashCommandDescriptions,
     pendingSubmissionsSlashCommandValidator,
     pendingSubmissionsSolver,
-    CachedPendingSubmissionsInteraction.cache,
+    false,
+    true,
 );
 
 export default PendingSubmissionsCommand;

--- a/src/types/InteractionCacheService.ts
+++ b/src/types/InteractionCacheService.ts
@@ -1,0 +1,7 @@
+import { Snowflake } from 'discord.js';
+import { CachedInteraction } from './cachedInteractions.js';
+
+export interface InteractionCacheService {
+    cacheInteraction(messageId: Snowflake, cachedInteraction: CachedInteraction): void;
+    getCachedInteraction(messageId: Snowflake): CachedInteraction | undefined;
+}

--- a/src/types/cachedInteractions.ts
+++ b/src/types/cachedInteractions.ts
@@ -1,147 +1,53 @@
 import { Snowflake } from 'discord.js';
-import { ChallengesSolverParams, challengesSolver, challengesSlashCommandDescriptions, ChallengesStatus } from '../commands/slashcommands/challenges.js';
-import { TournamentionClient } from './client.js';
-import { defaultSlashCommandDescriptions } from './defaultSlashCommandDescriptions.js';
-import { SlashCommandDescribedOutcome, SlashCommandEmbedDescribedOutcome, Outcome, OutcomeStatus } from './outcome.js';
+import { SlashCommandDescribedOutcome, SlashCommandEmbedDescribedOutcome, OutcomeTypeConstraint } from './outcome.js';
 import { PaginatedSolverParams } from './paginatedSolverParams.js';
-import { PendingSubmissionsSolverParams, PendingSubmissionsStatus, pendingSubmissionsSlashCommandDescriptions, pendingSubmissionsSolver } from '../commands/slashcommands/pending-submissions/pending-submissions-exports.js';
-
-enum CachedInteractionType {
-    DEFAULT = 'DEFAULT',
-    CHALLENGES = 'CHALLENGES',
-    PENDING_SUBMISSIONS = 'PENDING_SUBMISSIONS',
-}
-
-type BaseCacheParams = {
-    client: TournamentionClient;
-    messageId: Snowflake;
-    senderId: string;
-}
-
-export type PaginatedCacheParams = BaseCacheParams & {
-    totalPages: number;
-}
+import { InteractionCacheServiceLocator } from './interactionCacheServiceLocator.js';
+import { RendezvousCommand } from '../commands/architecture/rendezvousCommand.js';
 
 export interface CachedInteraction {
     messageId: Snowflake;
     senderId: string;
-    type: CachedInteractionType;
     totalPages: number;
+    solverParams: PaginatedSolverParams;
     solveAgainAndDescribe(page: number): Promise<SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome>;
+    setPage(page: number): void;
+    cache(): void;
 }
 
-export class Cacher {
+export abstract class BaseCachedInteraction implements CachedInteraction {
     constructor(
+        public readonly messageId: Snowflake,
+        public readonly senderId: string,
+        public readonly totalPages: number,
         public readonly solverParams: PaginatedSolverParams,
     ) {
         this.solverParams = solverParams;
     }
 
-    public setPage(page: number): void {
-        this.solverParams.page = page;
-    }
-}
-
-/**
- * A class meant to be used for type-matching only.
- */
-export class CacherCachedInteraction extends Cacher implements CachedInteraction {
-    public type: CachedInteractionType = CachedInteractionType.DEFAULT;
-    constructor(
-        public readonly messageId: Snowflake,
-        public readonly senderId: string,
-        solverParams: PaginatedSolverParams, 
-        public readonly totalPages: number,
-    ) {
-        super(solverParams);
-        this.messageId = messageId;
-        this.senderId = senderId;
-        this.totalPages = totalPages;
-    }
-
-    public setPage(_page: number): void {
-        throw new Error(`Error in cachedInteractions.ts: CacherCachedInteraction is a type-matching class only and setPage() should not be called on it.`);
-    }
-
-    public async solveAgainAndDescribe(_page: number): Promise<SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome> {
-        throw new Error(`Error in cachedInteractions.ts: CacherCachedInteraction is a type-matching class only and solveAgainAndDescribe() should not be called on it.`);
-    }
-}
-
-export class CachedChallengesInteraction extends Cacher implements CachedInteraction {
-    public type: CachedInteractionType = CachedInteractionType.CHALLENGES;
-    constructor(
-        public readonly messageId: Snowflake,
-        public readonly senderId: string,
-        solverParams: ChallengesSolverParams,
-        public readonly totalPages: number,
-    ) {
-        super(solverParams);
-        this.messageId = messageId;
-        this.senderId = senderId;
-        this.totalPages = totalPages;
-    }
+    public abstract solveAgainAndDescribe(page: number): Promise<SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome>;
 
     public setPage(page: number): void {
         this.solverParams.page = page;
+    }
+
+    public cache(): void {
+        InteractionCacheServiceLocator.getService().cacheInteraction(this.messageId, this);
+    }
+}
+
+export class CachedCommandInteraction<O extends OutcomeTypeConstraint, S, T1> extends BaseCachedInteraction {
+    constructor(
+        public readonly command: RendezvousCommand<O, S, T1>,
+        messageId: Snowflake,
+        senderId: string,
+        solverParams: S,
+        totalPages: number,
+    ) {
+        super(messageId, senderId, totalPages, solverParams as unknown as PaginatedSolverParams);
     }
 
     public async solveAgainAndDescribe(page: number): Promise<SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome> {
-        const outcome = await challengesSolver({ ...(this.solverParams as ChallengesSolverParams), page });
-        if (challengesSlashCommandDescriptions.has(outcome.status as ChallengesStatus)) return challengesSlashCommandDescriptions.get(outcome.status as ChallengesStatus)!(outcome);
-        // Fallback to trying default descriptions
-        const defaultOutcome = outcome as unknown as Outcome<string>;
-        if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
-            return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
-        } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
-    }
-
-    public static readonly cacheParams: PaginatedCacheParams & {
-        solverParams: ChallengesSolverParams;
-    };
-
-    public static async cache(cacheParams: typeof CachedChallengesInteraction.cacheParams): Promise<void> {
-        const { client, messageId, senderId, solverParams } = cacheParams;
-        const interaction = new CachedChallengesInteraction(messageId, senderId, solverParams, cacheParams.totalPages);
-        client.cacheInteraction(messageId, interaction);
-    }
-}
-
-export class CachedPendingSubmissionsInteraction extends Cacher implements CachedInteraction {
-    public type: CachedInteractionType = CachedInteractionType.PENDING_SUBMISSIONS;
-    constructor(
-        public readonly messageId: Snowflake,
-        public readonly senderId: string,
-        solverParams: PendingSubmissionsSolverParams,
-        public readonly totalPages: number,
-    ) {
-        super(solverParams);
-        this.messageId = messageId;
-        this.senderId = senderId;
-        this.totalPages = totalPages;
-    }
-
-    public setPage(page: number): void {
-        this.solverParams.page = page;
-    }
-
-    public async solveAgainAndDescribe(page: number): Promise<SlashCommandDescribedOutcome | SlashCommandEmbedDescribedOutcome> {
-        const outcome = await pendingSubmissionsSolver({ ...(this.solverParams as PendingSubmissionsSolverParams), page });
-        if (pendingSubmissionsSlashCommandDescriptions.has(outcome.status as PendingSubmissionsStatus)) return pendingSubmissionsSlashCommandDescriptions.get(outcome.status as PendingSubmissionsStatus)!(outcome);
-        // Fallback to trying default descriptions
-        const defaultOutcome = outcome as unknown as Outcome<string>;
-        if (defaultSlashCommandDescriptions.has(defaultOutcome.status)) {
-            return defaultSlashCommandDescriptions.get(defaultOutcome.status)!(defaultOutcome);
-        } else return defaultSlashCommandDescriptions.get(OutcomeStatus.FAIL_UNKNOWN)!(defaultOutcome);
-    }
-
-    public static readonly cacheParams: PaginatedCacheParams & {
-        solverParams: PendingSubmissionsSolverParams;
-    };
-
-    public static async cache(cacheParams: typeof CachedPendingSubmissionsInteraction.cacheParams): Promise<void> {
-        const { client, messageId, senderId, solverParams } = cacheParams;
-        const interaction = new CachedPendingSubmissionsInteraction(messageId, senderId, solverParams, cacheParams.totalPages);
-        client.cacheInteraction(messageId, interaction);
+        const outcome = await this.command.solver({ ...(this.solverParams as unknown as S), page });
+        return this.command.describer(outcome);
     }
 }

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,9 +1,8 @@
-import { Client, Collection, GatewayIntentBits, Snowflake } from 'discord.js';
+import { Client, Collection, GatewayIntentBits } from 'discord.js';
 import { RendezvousSlashCommand } from '../commands/architecture/rendezvousCommand.js';
 import { OutcomeTypeConstraint } from './outcome.js';
 import config from '../config.js';
 import CustomButton from '../buttons/architecture/CustomButton.js';
-import { CachedInteraction } from './cachedInteractions.js';
 
 // Type alias for RendezvousSlashCommand with unknown generic parameters.
 type RdvsSlashCommandAlias = RendezvousSlashCommand<OutcomeTypeConstraint, unknown, unknown>;
@@ -22,7 +21,6 @@ export class TournamentionClient extends Client {
     private static instance: TournamentionClient;
     private commands: Collection<string, RdvsSlashCommandAlias>;
     private buttons: Collection<string, CustomButton>;
-    private interactionCache: Collection<string, CachedInteraction>;
 
     private constructor() {
         const intents = [GatewayIntentBits.Guilds];
@@ -32,7 +30,6 @@ export class TournamentionClient extends Client {
         });
         this.commands = new Collection();
         this.buttons = new Collection();
-        this.interactionCache = new Collection();
         TournamentionClient.instance = this;
     }
 
@@ -58,18 +55,6 @@ export class TournamentionClient extends Client {
 
     public getButton(customId: string): CustomButton | undefined {
         return this.buttons.get(customId);
-    }
-
-    public cacheInteraction(messageId: Snowflake, cachedInteraction: CachedInteraction): void {
-        this.interactionCache.set(messageId, cachedInteraction);
-        setTimeout(() => {
-            this.interactionCache.delete(messageId);
-        }, 14 * 60 * 1000);
-        // TODO: Delete the interaction after < 15 minutes
-    }
-
-    public getCachedInteraction(messageId: Snowflake): CachedInteraction | undefined {
-        return this.interactionCache.get(messageId);
     }
 
     public static async getInstance(): Promise<TournamentionClient> {

--- a/src/types/inMemoryInteractionCacheService.ts
+++ b/src/types/inMemoryInteractionCacheService.ts
@@ -1,0 +1,18 @@
+import { Collection, Snowflake } from 'discord.js';
+import { CachedInteraction } from './cachedInteractions';
+import { InteractionCacheService } from './InteractionCacheService';
+
+export class InMemoryInteractionCacheService implements InteractionCacheService {
+    private interactionCache: Collection<string, CachedInteraction> = new Collection();
+
+    public cacheInteraction(messageId: Snowflake, cachedInteraction: CachedInteraction): void {
+        this.interactionCache.set(messageId, cachedInteraction);
+        setTimeout(() => {
+            this.interactionCache.delete(messageId);
+        }, 14 * 60 * 1000);
+    }
+
+    public getCachedInteraction(messageId: Snowflake): CachedInteraction | undefined {
+        return this.interactionCache.get(messageId);
+    }
+}

--- a/src/types/interactionCacheServiceLocator.ts
+++ b/src/types/interactionCacheServiceLocator.ts
@@ -1,0 +1,17 @@
+import { InteractionCacheService } from './InteractionCacheService.js';
+import { InMemoryInteractionCacheService } from './inMemoryInteractionCacheService.js';
+
+export class InteractionCacheServiceLocator {
+    private static service: InteractionCacheService;
+
+    public static getService(): InteractionCacheService {
+        if (!this.service) {
+            this.service = new InMemoryInteractionCacheService();
+        }
+        return this.service;
+    }
+
+    public static setService(service: InteractionCacheService): void {
+        this.service = service;
+    }
+}


### PR DESCRIPTION
Closes #121, #122

This is the first dedicated step towards the overall goal of extracting Rendezvous to its own NPM library for use in this and any other Discord bot (#120). In order to do so, Rendezvous needs to be totally isolated from Tournamention and generalized for clients to use as desired.

One of the specific isolation and generalization problems this PR addresses is the lack of generalized cached command interaction classes (#121). Implementing took no big revelation and I could've done it when this feature was originally added: there's now one concrete class that uses the `solverParams` of the underlying command's solver as a generic type parameter with the assumption(!) that the provided `solverParams` type parameter `S` conforms to the `PaginatedSolverParams` type (which is merely that `{ page: number }` are among its properties). I originally wanted to explicitly enforce `S extends PaginatedSolverParams`, but the reason I could not is the same reason it's not much of a problem*: the `CachedCommandInteraction` type parameters are taken from and exactly match the type parameters of the passed-in `RendezvousSlashCommand`.

<details>
<summary>*Aside on Rendezvous API misuse for cached commands</summary>
What happens if the client code requests their (embed slash-) command be cached without having a compliant <code>solverParams</code> such that <code>S extends PaginatedSolverParams</code>? I tested this with /profile. In that case, nothing bad happens, because the outcome object is not a <code>PaginatedOutcome</code>, so it never gets cached in the first place. If it were? In such a contrived situation, the bot would crash on the first use of that command with the standard Node "cannot read properties of undefined" error message. I'd consider this a clear enough error, but of course I'd want more explicit messages for users of my library when the times comes. 
</details>

The other isolation/generalization (as well as simply desirable) feature is the extraction of interaction cache updates and retrievals from the client class to a standalone class (#122). I've been learning C# and the .NET framework and I have been very impressed by the built-in dependency injection support. I wanted to do something similar here to let parts of the code manipulate the interaction cache without the need for access to the client Singleton object (SRP violation among other glaring problems). Without a DI container system like in .NET (though these exist as third party libraries), I opted also for a Singleton-esque pattern "service locator", an interaction cache service interface, and one implementing concrete class which is the standard in-memory Dictionary cache. This lets it work as before in the typical environment and be mockable for a testing environment. How can you not love dependency injection? The code that actually gets run is exactly the same as before, just moved out of the client class.

With these two changes, the way client code needs to be set up to enable caching is far simpler. Those commands that have caching (i.e. paginated embed commands: /challenges, /pending-submissions) have had the appropriates updates made. The same goes for the embed navigation buttons, which access and manipulate the interaction cache in the new way.

Another minor improvement is allowing clients to defer Rendezvous command replies in Discord with an optional argument. 